### PR TITLE
feat: ダッシュボード右上をリデザイン（歯車メニュー内に機能を集約）

### DIFF
--- a/app/extension/components/SettingsMenu.tsx
+++ b/app/extension/components/SettingsMenu.tsx
@@ -4,9 +4,10 @@ import { ThemeToggle } from "./ThemeToggle";
 
 interface Props {
   onClearData: () => void;
+  onExport?: () => void;
 }
 
-export function SettingsMenu({ onClearData }: Props) {
+export function SettingsMenu({ onClearData, onExport }: Props) {
   const { colors } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -80,6 +81,56 @@ export function SettingsMenu({ onClearData }: Props) {
           <div style={{ padding: "4px", borderBottom: `1px solid ${colors.border}` }}>
             <ThemeToggle />
           </div>
+
+          {onExport && (
+            <div style={{ padding: "4px", borderBottom: `1px solid ${colors.border}` }}>
+              <button
+                onClick={() => {
+                  setIsOpen(false);
+                  onExport();
+                }}
+                style={{
+                  width: "100%",
+                  padding: "8px 12px",
+                  background: "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  fontSize: "13px",
+                  color: colors.textPrimary,
+                  borderRadius: "4px",
+                  textAlign: "left",
+                  transition: "background-color 0.15s",
+                }}
+                onMouseEnter={(e) => {
+                  (e.currentTarget as HTMLButtonElement).style.backgroundColor = colors.bgSecondary;
+                }}
+                onMouseLeave={(e) => {
+                  (e.currentTarget as HTMLButtonElement).style.backgroundColor = "transparent";
+                }}
+              >
+                <span style={{ width: "16px", display: "flex", justifyContent: "center" }}>
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="7 10 12 15 17 10" />
+                    <line x1="12" y1="15" x2="12" y2="3" />
+                  </svg>
+                </span>
+                エクスポート
+              </button>
+            </div>
+          )}
 
           <div style={{ padding: "4px" }}>
             <button

--- a/app/extension/entrypoints/dashboard/App.tsx
+++ b/app/extension/entrypoints/dashboard/App.tsx
@@ -10,7 +10,7 @@ import type {
   EventLog,
 } from "@service-policy-auditor/detectors";
 import { ThemeContext, useThemeState, useTheme, type ThemeColors } from "../../lib/theme";
-import { Badge, Button, Card, DataTable, SearchInput, Select, StatCard, Tabs, ThemeToggle } from "../../components";
+import { Badge, Button, Card, DataTable, SearchInput, Select, SettingsMenu, StatCard, Tabs } from "../../components";
 
 interface Stats {
   violations: number;
@@ -425,7 +425,6 @@ function DashboardContent() {
             </p>
           </div>
           <div style={styles.controls}>
-            <ThemeToggle />
             <Select
               value={period}
               onChange={(v) => setPeriod(v as Period)}
@@ -434,8 +433,7 @@ function DashboardContent() {
             <Button onClick={() => loadData()} disabled={isRefreshing}>
               {isRefreshing ? "更新中..." : "更新"}
             </Button>
-            <Button variant="ghost" onClick={handleExportJSON}>エクスポート</Button>
-            <Button variant="ghost" onClick={handleClearData}>削除</Button>
+            <SettingsMenu onClearData={handleClearData} onExport={handleExportJSON} />
           </div>
         </div>
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/hikae/ghq/github.com/HikaruEgashira/service-policy-auditor/node_modules


### PR DESCRIPTION
## 概要

ダッシュボード右上のUIを整理し、使用頻度の低い機能を歯車メニュー（SettingsMenu）内に移動しました。

## 変更内容

### Before
```
[ThemeToggle] [期間選択 ▼] [更新] [エクスポート] [削除]
```

### After
```
[期間選択 ▼] [更新] [⚙️ ▼]
                      ├─ ThemeToggle
                      ├─ エクスポート
                      └─ データを削除
```

## 技術的な変更

1. **SettingsMenu.tsx**
   - Props に `onExport?: () => void` を追加
   - エクスポートメニュー項目を追加（ThemeToggleの下、削除の上）
   - ダウンロードアイコン用SVGを追加

2. **Dashboard App.tsx**
   - controls部分からThemeToggle、エクスポートボタン、削除ボタンを削除
   - SettingsMenuコンポーネントを追加
   - import文を更新（ThemeToggle削除、SettingsMenu追加）

## 互換性

- `onExport`はoptionalなので、既存のpopup/App.tsxは変更不要
- ポップアップは引き続き正常動作

## 動作確認

- ダッシュボード右上に期間選択・更新・歯車アイコンのみ表示
- 歯車アイコンをクリックすると、ドロップダウンにThemeToggle・エクスポート・削除が表示
- 各メニュー項目が正常に動作することを確認
- ポップアップの歯車メニューが引き続き正常動作