### PR TITLE
refactor: deduplicate type definitions

### DIFF
--- a/app/extension/entrypoints/background.ts
+++ b/app/extension/entrypoints/background.ts
@@ -12,9 +12,12 @@ import type {
   AIMonitorConfig,
   NRDConfig,
   NRDResult,
+  NRDCache,
   TyposquatConfig,
   TyposquatResult,
   TyposquatDetectedDetails,
+  TyposquatCache,
+  DetectionResult,
 } from "@service-policy-auditor/detectors";
 import {
   DEFAULT_AI_MONITOR_CONFIG,
@@ -72,13 +75,7 @@ let eventStore: EventStore | null = null;
 const nrdCache: Map<string, NRDResult> = new Map();
 let nrdDetector: ReturnType<typeof createNRDDetector> | null = null;
 
-interface NRDCacheAdapter {
-  get(domain: string): NRDResult | null;
-  set(domain: string, result: NRDResult): void;
-  clear(): void;
-}
-
-const nrdCacheAdapter: NRDCacheAdapter = {
+const nrdCacheAdapter: NRDCache = {
   get: (domain) => nrdCache.get(domain) ?? null,
   set: (domain, result) => nrdCache.set(domain, result),
   clear: () => nrdCache.clear(),
@@ -88,13 +85,7 @@ const nrdCacheAdapter: NRDCacheAdapter = {
 const typosquatCache: Map<string, TyposquatResult> = new Map();
 let typosquatDetector: ReturnType<typeof createTyposquatDetector> | null = null;
 
-interface TyposquatCacheAdapter {
-  get(domain: string): TyposquatResult | null;
-  set(domain: string, result: TyposquatResult): void;
-  clear(): void;
-}
-
-const typosquatCacheAdapter: TyposquatCacheAdapter = {
+const typosquatCacheAdapter: TyposquatCache = {
   get: (domain) => typosquatCache.get(domain) ?? null,
   set: (domain, result) => typosquatCache.set(domain, result),
   clear: () => typosquatCache.clear(),
@@ -419,16 +410,8 @@ interface PageAnalysis {
   domain: string;
   timestamp: number;
   login: LoginDetectedDetails;
-  privacy: {
-    found: boolean;
-    url: string | null;
-    method: string;
-  };
-  tos: {
-    found: boolean;
-    url: string | null;
-    method: string;
-  };
+  privacy: DetectionResult;
+  tos: DetectionResult;
 }
 
 async function handlePageAnalysis(analysis: PageAnalysis) {

--- a/app/extension/entrypoints/popup/components/CspPanel.tsx
+++ b/app/extension/entrypoints/popup/components/CspPanel.tsx
@@ -1,12 +1,8 @@
-import type { CSPViolation } from "@service-policy-auditor/csp";
 import { ViolationList } from "./ViolationList";
 import { PolicyGenerator } from "./PolicyGenerator";
+import type { ViolationProps } from "../types";
 
-interface Props {
-  violations: CSPViolation[];
-}
-
-export function CspPanel({ violations }: Props) {
+export function CspPanel({ violations }: ViolationProps) {
   return (
     <>
       <ViolationList violations={violations} />

--- a/app/extension/entrypoints/popup/components/DomainList.tsx
+++ b/app/extension/entrypoints/popup/components/DomainList.tsx
@@ -1,12 +1,9 @@
 import type { DetectedService } from "@service-policy-auditor/detectors";
 import { Badge } from "../../../components";
 import { usePopupStyles } from "../styles";
+import type { ServiceProps } from "../types";
 
-interface Props {
-  services: DetectedService[];
-}
-
-export function DomainList({ services }: Props) {
+export function DomainList({ services }: ServiceProps) {
   const styles = usePopupStyles();
 
   // NRDまたはTyposquatが検出されたサービスのみフィルタ

--- a/app/extension/entrypoints/popup/components/MalwareTab.tsx
+++ b/app/extension/entrypoints/popup/components/MalwareTab.tsx
@@ -1,16 +1,11 @@
-import type { CSPViolation, NetworkRequest } from "@service-policy-auditor/csp";
 import { ViolationList } from "./ViolationList";
 import { NetworkList } from "./NetworkList";
 import { PolicyGenerator } from "./PolicyGenerator";
 import { CSPSettings } from "./CSPSettings";
 import { usePopupStyles } from "../styles";
+import type { MalwareTabProps } from "../types";
 
-interface Props {
-  violations: CSPViolation[];
-  networkRequests: NetworkRequest[];
-}
-
-export function MalwareTab({ violations, networkRequests }: Props) {
+export function MalwareTab({ violations, networkRequests }: MalwareTabProps) {
   const styles = usePopupStyles();
 
   return (

--- a/app/extension/entrypoints/popup/components/PhishingTab.tsx
+++ b/app/extension/entrypoints/popup/components/PhishingTab.tsx
@@ -1,15 +1,10 @@
-import type { DetectedService, EventLog } from "@service-policy-auditor/detectors";
 import { DomainList } from "./DomainList";
 import { EventLogList } from "./EventLog";
 import { NRDSettings } from "./NRDSettings";
 import { usePopupStyles } from "../styles";
+import type { PhishingTabProps } from "../types";
 
-interface Props {
-  services: DetectedService[];
-  events: EventLog[];
-}
-
-export function PhishingTab({ services, events }: Props) {
+export function PhishingTab({ services, events }: PhishingTabProps) {
   const styles = usePopupStyles();
 
   return (

--- a/app/extension/entrypoints/popup/components/ServiceList.tsx
+++ b/app/extension/entrypoints/popup/components/ServiceList.tsx
@@ -1,10 +1,7 @@
 import type { DetectedService } from "@service-policy-auditor/detectors";
 import { Badge, Card } from "../../../components";
 import { usePopupStyles } from "../styles";
-
-interface Props {
-  services: DetectedService[];
-}
+import type { ServiceProps } from "../types";
 
 function sanitizeUrl(url: string | null, domain: string): string {
   if (!url) {
@@ -22,7 +19,7 @@ function sanitizeUrl(url: string | null, domain: string): string {
   }
 }
 
-export function ServiceList({ services }: Props) {
+export function ServiceList({ services }: ServiceProps) {
   const styles = usePopupStyles();
 
   if (services.length === 0) {

--- a/app/extension/entrypoints/popup/components/ShadowITTab.tsx
+++ b/app/extension/entrypoints/popup/components/ShadowITTab.tsx
@@ -1,14 +1,8 @@
-import type { DetectedService, EventLog, CapturedAIPrompt } from "@service-policy-auditor/detectors";
 import { ServiceList } from "./ServiceList";
 import { AIPromptList } from "./AIPromptList";
 import { EventLogList } from "./EventLog";
 import { usePopupStyles } from "../styles";
-
-interface Props {
-  services: DetectedService[];
-  aiPrompts: CapturedAIPrompt[];
-  events: EventLog[];
-}
+import type { ShadowITTabProps } from "../types";
 
 const SHADOW_IT_EVENT_TYPES = [
   "cookie_set",
@@ -17,7 +11,7 @@ const SHADOW_IT_EVENT_TYPES = [
   "terms_of_service_found",
 ];
 
-export function ShadowITTab({ services, aiPrompts, events }: Props) {
+export function ShadowITTab({ services, aiPrompts, events }: ShadowITTabProps) {
   const styles = usePopupStyles();
 
   return (

--- a/app/extension/entrypoints/popup/components/ViolationList.tsx
+++ b/app/extension/entrypoints/popup/components/ViolationList.tsx
@@ -3,12 +3,9 @@ import type { CSPViolation } from "@service-policy-auditor/csp";
 import { Badge } from "../../../components";
 import { usePopupStyles } from "../styles";
 import { useTheme } from "../../../lib/theme";
+import type { ViolationProps } from "../types";
 
-interface Props {
-  violations: CSPViolation[];
-}
-
-export function ViolationList({ violations }: Props) {
+export function ViolationList({ violations }: ViolationProps) {
   const styles = usePopupStyles();
   const { colors } = useTheme();
   const [expandedId, setExpandedId] = useState<string | null>(null);

--- a/app/extension/entrypoints/popup/types.ts
+++ b/app/extension/entrypoints/popup/types.ts
@@ -1,0 +1,28 @@
+import type { CSPViolation, NetworkRequest } from "@service-policy-auditor/csp";
+import type {
+  DetectedService,
+  EventLog,
+  CapturedAIPrompt,
+} from "@service-policy-auditor/detectors";
+
+export interface ViolationProps {
+  violations: CSPViolation[];
+}
+
+export interface ServiceProps {
+  services: DetectedService[];
+}
+
+export interface EventProps {
+  events: EventLog[];
+}
+
+export interface PhishingTabProps extends ServiceProps, EventProps {}
+
+export interface ShadowITTabProps extends ServiceProps, EventProps {
+  aiPrompts: CapturedAIPrompt[];
+}
+
+export interface MalwareTabProps extends ViolationProps {
+  networkRequests: NetworkRequest[];
+}


### PR DESCRIPTION
## Summary
- similarity-tsで検出された型の重複を解消
- 冗長なCacheAdapter型定義を削除し、パッケージの型を使用
- PageAnalysis型をDetectionResult型で統一
- 共通Props型をtypes.tsに抽出（6コンポーネントで使用）

## Test plan
- [x] `pnpm build` 成功
- [x] similarity-ts再実行で型類似性 10件→2件に削減を確認