### PR TITLE
perf: add pagination and period filtering for data queries

### DIFF
--- a/app/extension/entrypoints/popup/App.tsx
+++ b/app/extension/entrypoints/popup/App.tsx
@@ -78,7 +78,7 @@ function PopupContent() {
     try {
       const [servicesResult, eventsResult] = await Promise.all([
         chrome.storage.local.get(["services"]),
-        chrome.runtime.sendMessage({ type: "GET_EVENTS", data: { limit: 10000, offset: 0 } }),
+        chrome.runtime.sendMessage({ type: "GET_EVENTS", data: { limit: 100, offset: 0 } }),
       ]);
 
       const events = (eventsResult as EventQueryResult | undefined)?.events || [];

--- a/packages/api/db/interface.ts
+++ b/packages/api/db/interface.ts
@@ -6,6 +6,19 @@ export interface DatabaseStats {
   uniqueDomains: number
 }
 
+export interface QueryOptions {
+  limit?: number
+  offset?: number
+  since?: string
+  until?: string
+}
+
+export interface PaginatedResult<T> {
+  data: T[]
+  total: number
+  hasMore: boolean
+}
+
 export interface DatabaseAdapter {
   init(): Promise<void>
   insertReports(reports: CSPReport[]): Promise<void>
@@ -16,4 +29,7 @@ export interface DatabaseAdapter {
   clearAll(): Promise<void>
   close(): Promise<void>
   getReportsSince(timestamp: string): Promise<CSPReport[]>
+  getReports(options?: QueryOptions): Promise<PaginatedResult<CSPReport>>
+  getViolations(options?: QueryOptions): Promise<PaginatedResult<CSPViolation>>
+  getNetworkRequests(options?: QueryOptions): Promise<PaginatedResult<NetworkRequest>>
 }

--- a/packages/api/routes/reports.ts
+++ b/packages/api/routes/reports.ts
@@ -1,13 +1,61 @@
 import { Hono } from 'hono'
-import type { DatabaseAdapter } from '../db/interface'
+import type { DatabaseAdapter, QueryOptions } from '../db/interface'
 import type { CSPReport } from '@service-policy-auditor/csp'
+
+function parseQueryOptions(c: { req: { query: (key: string) => string | undefined } }): QueryOptions {
+  const limit = c.req.query('limit')
+  const offset = c.req.query('offset')
+  const since = c.req.query('since')
+  const until = c.req.query('until')
+
+  return {
+    limit: limit ? parseInt(limit, 10) : undefined,
+    offset: offset ? parseInt(offset, 10) : undefined,
+    since: since || undefined,
+    until: until || undefined,
+  }
+}
 
 export function createReportsRoutes(db: DatabaseAdapter) {
   const app = new Hono()
 
   app.get('/', async (c) => {
+    const options = parseQueryOptions(c)
+
+    if (options.limit !== undefined || options.offset !== undefined || options.since || options.until) {
+      const result = await db.getReports(options)
+      return c.json({
+        reports: result.data,
+        total: result.total,
+        hasMore: result.hasMore,
+        lastUpdated: new Date().toISOString()
+      })
+    }
+
     const reports = await db.getAllReports()
     return c.json({ reports, lastUpdated: new Date().toISOString() })
+  })
+
+  app.get('/violations', async (c) => {
+    const options = parseQueryOptions(c)
+    const result = await db.getViolations(options)
+    return c.json({
+      violations: result.data,
+      total: result.total,
+      hasMore: result.hasMore,
+      lastUpdated: new Date().toISOString()
+    })
+  })
+
+  app.get('/network', async (c) => {
+    const options = parseQueryOptions(c)
+    const result = await db.getNetworkRequests(options)
+    return c.json({
+      requests: result.data,
+      total: result.total,
+      hasMore: result.hasMore,
+      lastUpdated: new Date().toISOString()
+    })
   })
 
   app.post('/', async (c) => {

--- a/packages/api/routes/sync.ts
+++ b/packages/api/routes/sync.ts
@@ -2,24 +2,44 @@ import { Hono } from 'hono'
 import type { DatabaseAdapter } from '../db/interface'
 import type { CSPReport } from '@service-policy-auditor/csp'
 
+const DEFAULT_BATCH_SIZE = 500
+
 export function createSyncRoutes(db: DatabaseAdapter) {
   const app = new Hono()
 
   app.get('/', async (c) => {
     const since = c.req.query('since') || '1970-01-01T00:00:00.000Z'
-    const reports = await db.getReportsSince(since)
-    return c.json({ reports, serverTime: new Date().toISOString() })
+    const limitParam = c.req.query('limit')
+    const limit = limitParam ? parseInt(limitParam, 10) : DEFAULT_BATCH_SIZE
+
+    const result = await db.getReports({ since, limit })
+    return c.json({
+      reports: result.data,
+      total: result.total,
+      hasMore: result.hasMore,
+      serverTime: new Date().toISOString()
+    })
   })
 
   app.post('/', async (c) => {
-    const body = await c.req.json<{ reports: CSPReport[], clientTime: string }>()
+    const body = await c.req.json<{ reports: CSPReport[], clientTime: string, limit?: number }>()
 
     if (body.reports?.length) {
       await db.insertReports(body.reports)
     }
 
-    const serverReports = await db.getReportsSince(body.clientTime || '1970-01-01T00:00:00.000Z')
-    return c.json({ serverReports, serverTime: new Date().toISOString() })
+    const limit = body.limit ?? DEFAULT_BATCH_SIZE
+    const result = await db.getReports({
+      since: body.clientTime || '1970-01-01T00:00:00.000Z',
+      limit
+    })
+
+    return c.json({
+      serverReports: result.data,
+      total: result.total,
+      hasMore: result.hasMore,
+      serverTime: new Date().toISOString()
+    })
   })
 
   return app

--- a/packages/extension-runtime/src/index.ts
+++ b/packages/extension-runtime/src/index.ts
@@ -17,6 +17,8 @@ export {
   updateApiClientConfig,
   type ConnectionMode,
   type ApiClientConfig,
+  type QueryOptions,
+  type PaginatedResult,
 } from "./api-client.js";
 
 // Sync Manager


### PR DESCRIPTION
## Summary
- データベースクエリにページネーション（limit, offset）と期間フィルタリング（since, until）を追加
- ポップアップのイベント取得を10000件から100件に削減
- ダッシュボードのイベント取得を10000件から500件に削減、ポーリング間隔を5秒から30秒に延長
- 新しいAPIエンドポイント `/reports/violations` と `/reports/network` を追加

## Changes
- `packages/api/db/interface.ts`: QueryOptions, PaginatedResult インターフェース追加
- `packages/api/db/sql-js-adapter.ts`: ページネーション対応のクエリメソッド実装
- `packages/api/routes/reports.ts`: 新エンドポイントとクエリパラメータ対応
- `packages/api/routes/sync.ts`: デフォルトバッチサイズ500件に制限
- `packages/extension-runtime/src/api-client.ts`: クエリオプション対応
- `app/extension/entrypoints/popup/App.tsx`: イベント取得制限を100件に
- `app/extension/entrypoints/dashboard/App.tsx`: 期間フィルタリングとポーリング最適化

## Test plan
- [ ] ビルドが成功すること
- [ ] ポップアップでイベントが表示されること
- [ ] ダッシュボードで期間フィルタリングが動作すること
- [ ] CSPレポートの取得が正常に動作すること