### PR TITLE
feat: add browser agent CLI and change typosquat badge to warning

### DIFF
--- a/app/debugger/package.json
+++ b/app/debugger/package.json
@@ -12,10 +12,12 @@
     "install-host": "tsx src/install.ts"
   },
   "dependencies": {
+    "chrome-remote-interface": "^0.33.2",
     "commander": "^13.1.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@types/chrome-remote-interface": "^0.33.0",
     "@types/node": "^22.16.0",
     "@types/ws": "^8.18.0",
     "tsx": "^4.21.0",

--- a/app/debugger/src/cdp-client.ts
+++ b/app/debugger/src/cdp-client.ts
@@ -1,0 +1,110 @@
+/**
+ * Chrome DevTools Protocol (CDP) client for browser automation.
+ * Connects to Chrome's remote debugging port.
+ */
+import CDP from "chrome-remote-interface";
+
+const CDP_PORT = 9333;
+
+export interface CDPConnection {
+  client: CDP.Client;
+  Page: CDP.Client["Page"];
+  Runtime: CDP.Client["Runtime"];
+  DOM: CDP.Client["DOM"];
+  Accessibility: CDP.Client["Accessibility"];
+  close: () => Promise<void>;
+}
+
+/**
+ * Connect to Chrome's CDP endpoint.
+ */
+export async function connectCDP(port = CDP_PORT): Promise<CDPConnection> {
+  const client = await CDP({ port });
+  const { Page, Runtime, DOM, Accessibility } = client;
+
+  await Promise.all([Page.enable(), Runtime.enable(), DOM.enable()]);
+
+  return {
+    client,
+    Page,
+    Runtime,
+    DOM,
+    Accessibility,
+    close: async () => {
+      await client.close();
+    },
+  };
+}
+
+/**
+ * Navigate to a URL.
+ */
+export async function navigate(
+  conn: CDPConnection,
+  url: string
+): Promise<void> {
+  await conn.Page.navigate({ url });
+  await conn.Page.loadEventFired();
+}
+
+/**
+ * Take a screenshot and return as base64.
+ */
+export async function screenshot(conn: CDPConnection): Promise<string> {
+  const result = await conn.Page.captureScreenshot({ format: "png" });
+  return result.data;
+}
+
+/**
+ * Execute JavaScript in the page context.
+ */
+export async function evaluate(
+  conn: CDPConnection,
+  expression: string
+): Promise<unknown> {
+  const result = await conn.Runtime.evaluate({
+    expression,
+    returnByValue: true,
+  });
+  if (result.exceptionDetails) {
+    throw new Error(result.exceptionDetails.text);
+  }
+  return result.result.value;
+}
+
+/**
+ * Click an element by selector.
+ */
+export async function click(
+  conn: CDPConnection,
+  selector: string
+): Promise<void> {
+  await evaluate(conn, `document.querySelector('${selector}')?.click()`);
+}
+
+/**
+ * Get accessibility tree (for AI agent use).
+ */
+export async function getAccessibilityTree(
+  conn: CDPConnection
+): Promise<unknown> {
+  await conn.Accessibility.enable();
+  const { nodes } = await conn.Accessibility.getFullAXTree();
+  return nodes;
+}
+
+/**
+ * Get page title.
+ */
+export async function getTitle(conn: CDPConnection): Promise<string> {
+  const result = await evaluate(conn, "document.title");
+  return String(result);
+}
+
+/**
+ * Get current URL.
+ */
+export async function getUrl(conn: CDPConnection): Promise<string> {
+  const result = await evaluate(conn, "window.location.href");
+  return String(result);
+}

--- a/app/debugger/src/cli.ts
+++ b/app/debugger/src/cli.ts
@@ -9,6 +9,8 @@ import { messageCommand } from "./commands/message.js";
 import { watchCommand } from "./commands/watch.js";
 import { logsCommand } from "./commands/logs.js";
 import { installCommand as serverCommand } from "./commands/install.js";
+import { browserCommand } from "./commands/browser.js";
+import { launchCommand } from "./commands/launch.js";
 
 const program = new Command();
 
@@ -33,5 +35,9 @@ program.addCommand(servicesCommand);
 program.addCommand(messageCommand);
 program.addCommand(watchCommand);
 program.addCommand(logsCommand);
+
+// Browser automation
+program.addCommand(launchCommand);
+program.addCommand(browserCommand);
 
 program.parse();

--- a/app/debugger/src/commands/browser.ts
+++ b/app/debugger/src/commands/browser.ts
@@ -1,0 +1,131 @@
+import { Command } from "commander";
+import { writeFileSync } from "node:fs";
+import {
+  connectCDP,
+  navigate,
+  screenshot,
+  click,
+  evaluate,
+  getAccessibilityTree,
+  getTitle,
+  getUrl,
+} from "../cdp-client.js";
+
+export const browserCommand = new Command("browser").description(
+  "Browser automation via CDP"
+);
+
+browserCommand
+  .command("open <url>")
+  .description("Navigate to URL")
+  .action(async (url: string) => {
+    try {
+      const conn = await connectCDP();
+      await navigate(conn, url);
+      const title = await getTitle(conn);
+      console.log(`\x1b[32m✓\x1b[0m \x1b[1m${title}\x1b[0m`);
+      console.log(`\x1b[2m  ${url}\x1b[0m`);
+      await conn.close();
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+      console.error("Is Chrome running with --remote-debugging-port=9333?");
+      process.exit(1);
+    }
+  });
+
+browserCommand
+  .command("screenshot [path]")
+  .description("Take screenshot")
+  .action(async (path?: string) => {
+    try {
+      const conn = await connectCDP();
+      const data = await screenshot(conn);
+      const filename = path || `screenshot-${Date.now()}.png`;
+      writeFileSync(filename, Buffer.from(data, "base64"));
+      console.log(`\x1b[32m✓\x1b[0m Screenshot saved: ${filename}`);
+      await conn.close();
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+      process.exit(1);
+    }
+  });
+
+browserCommand
+  .command("click <selector>")
+  .description("Click element by CSS selector")
+  .action(async (selector: string) => {
+    try {
+      const conn = await connectCDP();
+      await click(conn, selector);
+      console.log(`\x1b[32m✓\x1b[0m Clicked: ${selector}`);
+      await conn.close();
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+      process.exit(1);
+    }
+  });
+
+browserCommand
+  .command("eval <js>")
+  .description("Evaluate JavaScript")
+  .action(async (js: string) => {
+    try {
+      const conn = await connectCDP();
+      const result = await evaluate(conn, js);
+      console.log(result);
+      await conn.close();
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+      process.exit(1);
+    }
+  });
+
+browserCommand
+  .command("snapshot")
+  .description("Get accessibility tree (for AI)")
+  .option("-p, --pretty", "Pretty print JSON")
+  .action(async (options: { pretty?: boolean }) => {
+    try {
+      const conn = await connectCDP();
+      const tree = await getAccessibilityTree(conn);
+      if (options.pretty) {
+        console.log(JSON.stringify(tree, null, 2));
+      } else {
+        console.log(JSON.stringify(tree));
+      }
+      await conn.close();
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+      process.exit(1);
+    }
+  });
+
+browserCommand
+  .command("status")
+  .description("Get current page info")
+  .action(async () => {
+    try {
+      const conn = await connectCDP();
+      const title = await getTitle(conn);
+      const url = await getUrl(conn);
+      console.log(`Title: ${title}`);
+      console.log(`URL: ${url}`);
+      await conn.close();
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+      console.error("Is Chrome running with --remote-debugging-port=9333?");
+      process.exit(1);
+    }
+  });

--- a/app/debugger/src/commands/launch.ts
+++ b/app/debugger/src/commands/launch.ts
@@ -1,0 +1,140 @@
+import { Command } from "commander";
+import { spawn, ChildProcess } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+import { getDebugServer, waitForExtension } from "../server.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Find extension dist directory (prefer dev build for debug-bridge)
+function findExtensionDir(): string {
+  const candidates = [
+    resolve(__dirname, "../../../extension/dist/chrome-mv3-dev"),
+    resolve(__dirname, "../../../../app/extension/dist/chrome-mv3-dev"),
+    resolve(__dirname, "../../../extension/dist/chrome-mv3"),
+    resolve(__dirname, "../../../../app/extension/dist/chrome-mv3"),
+  ];
+
+  for (const dir of candidates) {
+    if (existsSync(dir)) {
+      return dir;
+    }
+  }
+
+  throw new Error(
+    "Extension dist not found. Run `pnpm --filter @pleno-audit/extension dev` first to build with debug-bridge."
+  );
+}
+
+let chromeProcess: ChildProcess | null = null;
+
+export const launchCommand = new Command("launch")
+  .description("Launch Chrome with extension, CDP, and debug server")
+  .option("-p, --port <port>", "CDP port", "9333")
+  .option("-d, --debug-port <port>", "Debug server port", "9222")
+  .option("-u, --url <url>", "URL to open on launch")
+  .option("--no-wait", "Don't wait for extension to connect")
+  .action(
+    async (options: {
+      port: string;
+      debugPort: string;
+      url?: string;
+      wait: boolean;
+    }) => {
+      try {
+        // 1. Start debug server
+        console.log("Starting debug server on port 9222...");
+        const server = getDebugServer();
+
+        // 2. Find extension
+        const extensionDir = findExtensionDir();
+        console.log(`Extension: ${extensionDir}`);
+
+        // 3. Launch Chrome
+        const chromePath =
+          "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+
+        const args = [
+          `--remote-debugging-port=${options.port}`,
+          `--load-extension=${extensionDir}`,
+          "--no-first-run",
+          "--no-default-browser-check",
+          "--disable-background-timer-throttling",
+          `--user-data-dir=/tmp/pleno-debug-chrome-${Date.now()}`,
+        ];
+
+        // Open blank page first
+        args.push("about:blank");
+
+        console.log(`Starting Chrome with CDP on port ${options.port}...`);
+
+        chromeProcess = spawn(chromePath, args, {
+          detached: false,
+          stdio: "ignore",
+        });
+
+        chromeProcess.on("exit", (code) => {
+          console.log(`Chrome exited with code ${code}`);
+          server.close();
+          process.exit(0);
+        });
+
+        // 4. Wait for extension to connect
+        if (options.wait) {
+          console.log("Waiting for extension to connect...");
+          try {
+            await waitForExtension(15000);
+            console.log("\x1b[32m✓\x1b[0m Extension connected!");
+          } catch {
+            console.error(
+              "\x1b[33m⚠\x1b[0m Extension did not connect (debug-bridge may not be enabled)"
+            );
+          }
+        }
+
+        // 5. Navigate to URL if specified
+        if (options.url) {
+          // Use CDP to navigate
+          const CDP = await import("chrome-remote-interface");
+          const client = await CDP.default({ port: parseInt(options.port) });
+          const { Page } = client;
+          await Page.enable();
+          await Page.navigate({ url: options.url });
+          await Page.loadEventFired();
+          console.log(`\x1b[32m✓\x1b[0m Opened: ${options.url}`);
+          await client.close();
+
+          // Wait a bit for extension to detect services
+          await new Promise((r) => setTimeout(r, 2000));
+        }
+
+        console.log("");
+        console.log("\x1b[32m✓\x1b[0m Ready!");
+        console.log(`CDP endpoint: http://localhost:${options.port}`);
+        console.log(`Debug server: ws://localhost:9222`);
+        console.log("");
+        console.log("Commands:");
+        console.log("  pleno-debug browser open <url>    Navigate to URL");
+        console.log("  pleno-debug browser screenshot    Take screenshot");
+        console.log("  pleno-debug services list         Show detected services");
+        console.log("");
+        console.log("Press Ctrl+C to stop");
+
+        // Keep process running
+        process.on("SIGINT", () => {
+          console.log("\nShutting down...");
+          if (chromeProcess) {
+            chromeProcess.kill();
+          }
+          server.close();
+          process.exit(0);
+        });
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : "Unknown error"}`
+        );
+        process.exit(1);
+      }
+    }
+  );

--- a/app/extension/entrypoints/popup/components/ServicesTab.tsx
+++ b/app/extension/entrypoints/popup/components/ServicesTab.tsx
@@ -39,7 +39,7 @@ function TagBadge({ tag, domain }: { tag: ServiceTag; domain: string }) {
         </Badge>
       );
     case "typosquat":
-      return <Badge variant="danger" size="sm">Typosquat</Badge>;
+      return <Badge variant="warning" size="sm">Typosquat</Badge>;
     case "ai":
       return <Badge variant="warning" size="sm">AI</Badge>;
     case "login":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   app/debugger:
     dependencies:
+      chrome-remote-interface:
+        specifier: ^0.33.2
+        version: 0.33.3
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -24,6 +27,9 @@ importers:
         specifier: ^8.18.0
         version: 8.19.0
     devDependencies:
+      '@types/chrome-remote-interface':
+        specifier: ^0.33.0
+        version: 0.33.0
       '@types/node':
         specifier: ^22.16.0
         version: 22.19.5
@@ -974,6 +980,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chrome-remote-interface@0.33.0':
+    resolution: {integrity: sha512-c+VcrTFcgvpwbAF/MgWIuVzagzOSX6hDuZEwkRW3Bk1yu/xMlAh5G4ogYpQGtW7fVydVGSQ9WD/mEwqQehu73w==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1164,6 +1173,10 @@ packages:
     engines: {node: '>=12.13.0'}
     hasBin: true
 
+  chrome-remote-interface@0.33.3:
+    resolution: {integrity: sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw==}
+    hasBin: true
+
   ci-info@4.3.1:
     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
     engines: {node: '>=8'}
@@ -1204,6 +1217,9 @@ packages:
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
+
+  commander@2.11.0:
+    resolution: {integrity: sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==}
 
   commander@2.9.0:
     resolution: {integrity: sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==}
@@ -1319,6 +1335,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devtools-protocol@0.0.1173815:
+    resolution: {integrity: sha512-CmsjkudmgCMeae8FSJB4GV8COZwOk6dJKyE9HS2F/ih/sA8uTdbPKHg5F7DsrOYLEET/QKK00LJCU4YoyG+uHg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2542,6 +2561,18 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
@@ -3199,6 +3230,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
+  '@types/chrome-remote-interface@0.33.0':
+    dependencies:
+      devtools-protocol: 0.0.1173815
+
   '@types/estree@1.0.8': {}
 
   '@types/filesystem@0.0.36':
@@ -3400,6 +3435,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  chrome-remote-interface@0.33.3:
+    dependencies:
+      commander: 2.11.0
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ci-info@4.3.1: {}
 
   citty@0.1.6:
@@ -3434,6 +3477,8 @@ snapshots:
   colorette@2.0.20: {}
 
   commander@13.1.0: {}
+
+  commander@2.11.0: {}
 
   commander@2.9.0:
     dependencies:
@@ -3527,6 +3572,8 @@ snapshots:
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
+
+  devtools-protocol@0.0.1173815: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -4730,6 +4777,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.1.2
+
+  ws@7.5.10: {}
 
   ws@8.19.0: {}
 


### PR DESCRIPTION
## Summary
- Typosquatバッジを赤（danger）から黄色（warning）に変更
  - ヒューリスティックベースの検出なので、危険度を下げた
- pleno-debug CLIにブラウザ自動化機能を追加
  - CDP (Chrome DevTools Protocol) を使用

## 新しいコマンド
```bash
# Chrome を拡張機能付きで起動（CDP + デバッグサーバー）
pleno-debug launch -u https://zenn.dev

# ブラウザ操作
pleno-debug browser open <url>       # URLに遷移
pleno-debug browser screenshot       # スクリーンショット
pleno-debug browser click <selector> # 要素クリック
pleno-debug browser eval <js>        # JavaScript実行
pleno-debug browser snapshot         # アクセシビリティツリー
pleno-debug browser status           # 現在のページ情報
```

## TODO
- [ ] WXT開発サーバーとの統合（現在は別のChromeインスタンスを起動）
- [ ] zenn.devでTyposquatバッジが黄色で表示されることの動作確認

## Test plan
- [ ] `pleno-debug browser --help` でヘルプが表示される
- [ ] `pleno-debug launch -u https://example.com` でChromeが起動する
- [ ] `pleno-debug browser screenshot` でスクリーンショットが撮れる