### PR TITLE
feat: migrate AIPrompts to ParquetStore for unified log persistence

### DIFF
--- a/app/extension/wxt.config.ts
+++ b/app/extension/wxt.config.ts
@@ -46,6 +46,9 @@ export default defineConfig({
     },
     build: {
       target: "esnext",
+      rollupOptions: {
+        external: ["parquet-wasm", "@pleno-audit/parquet-storage"],
+      },
     },
     optimizeDeps: {
       include: [
@@ -53,7 +56,9 @@ export default defineConfig({
         "@pleno-audit/detectors",
         "@pleno-audit/api",
         "@pleno-audit/extension-runtime",
+        "@pleno-audit/parquet-storage",
       ],
+      exclude: ["parquet-wasm"],
     },
   }),
 });


### PR DESCRIPTION
## Summary

Migrate AIPrompt storage from chrome.storage.local to ParquetStore to unify log persistence strategy with CSP violations and network requests.

- Updated storeAIPrompt(), getAIPrompts(), getAIPromptsCount() to use ParquetStore
- Initialize AIPromptStore in background.ts on startup
- Updated data cleanup and clear operations for ParquetStore
- Added @pleno-audit/parquet-storage to build configuration

## Test plan

- [ ] Build succeeds without errors
- [ ] AI prompts are stored and retrieved correctly
- [ ] Data cleanup respects retention policy
- [ ] Clear AI data removes all Parquet records