### PR TITLE
feat: add automatic cleanup of old releases

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -51,3 +51,16 @@ jobs:
           prerelease: true
           generate_release_notes: true
           make_latest: false
+
+      - name: Cleanup old canary releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          KEEP_COUNT=10
+
+          gh release list --limit 1000 --json tagName,createdAt \
+            --jq "[.[] | select(.tagName | test(\"^v${VERSION}-canary\\\\.\"))] | sort_by(.createdAt) | reverse | .[${KEEP_COUNT}:] | .[].tagName" \
+            | while read -r tag; do
+              [ -n "$tag" ] && gh release delete "$tag" --yes --cleanup-tag && echo "Deleted: $tag"
+            done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,16 @@ jobs:
           files: extension.zip
           generate_release_notes: true
           make_latest: true
+
+      - name: Cleanup old releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          KEEP_COUNT=10
+
+          gh release list --limit 1000 --json tagName,createdAt \
+            --jq "[.[] | select(.tagName | test(\"^v${VERSION}-[a-f0-9]+$\"))] | sort_by(.createdAt) | reverse | .[${KEEP_COUNT}:] | .[].tagName" \
+            | while read -r tag; do
+              [ -n "$tag" ] && gh release delete "$tag" --yes --cleanup-tag && echo "Deleted: $tag"
+            done


### PR DESCRIPTION
## 概要
リリース作成後に古いタグ/リリースを自動削除する機能を追加しました。

## 変更内容
- **release.yml**: mainリリース作成後に同一パッチバージョン（`v0.0.1-*`）のうち最新10件のみを保持し、それ以前のリリースを削除
- **canary-release.yml**: canaryリリース作成後に同一パッチバージョン（`v0.0.1-canary.*`）のうち最新10件のみを保持し、それ以前のリリースを削除

## 技術詳細
- `gh release delete --cleanup-tag` でリリースとタグを同時削除
- jqでバージョンごとにフィルタリング、作成日時でソート
- `KEEP_COUNT`を変数化して将来の調整を容易化

## テスト予定
canaryブランチへのプッシュで動作を確認予定