### PR TITLE
feat: Firefox ブラウザサポートの追加

### DIFF
--- a/app/extension/entrypoints/background.ts
+++ b/app/extension/entrypoints/background.ts
@@ -1461,6 +1461,13 @@ async function triggerSync(): Promise<{ success: boolean; sent: number; received
 }
 
 async function registerMainWorldScript() {
+  // chrome.scripting is only available in Chrome MV3
+  // Firefox MV2 uses manifest-based content script registration
+  if (typeof chrome.scripting?.registerContentScripts !== "function") {
+    logger.debug("chrome.scripting not available (Firefox MV2), skipping dynamic registration");
+    return;
+  }
+
   try {
     await chrome.scripting.unregisterContentScripts({ ids: ["api-hooks"] }).catch(() => {});
     await chrome.scripting.registerContentScripts([{

--- a/app/extension/wxt.config.ts
+++ b/app/extension/wxt.config.ts
@@ -7,6 +7,17 @@ export default defineConfig({
   manifest: (env) => {
     const isDev = env.mode === "development";
     const iconPrefix = isDev ? "icon-dev" : "icon";
+    const isFirefox = env.browser === "firefox";
+
+    // Base permissions (cross-browser)
+    const basePermissions = ["cookies", "storage", "activeTab", "alarms", "webRequest", "management", "notifications"];
+
+    // Chrome-specific permissions
+    const chromePermissions = [...basePermissions, "offscreen", "scripting"];
+
+    // Firefox permissions (no offscreen, no scripting in MV2)
+    const firefoxPermissions = basePermissions;
+
     return {
       name: isDev ? "[DEV] Pleno Audit" : "Pleno Audit",
       version: "0.0.1",
@@ -24,18 +35,31 @@ export default defineConfig({
           48: `${iconPrefix}-48.png`,
         },
       },
-      permissions: ["cookies", "storage", "activeTab", "alarms", "offscreen", "scripting", "webRequest", "management", "notifications"],
+      permissions: isFirefox ? firefoxPermissions : chromePermissions,
       host_permissions: ["<all_urls>"],
-      content_security_policy: {
-        extension_pages:
-          "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';",
-      },
-      web_accessible_resources: [
-        {
-          resources: ["api-hooks.js", "ai-hooks.js", "sql-wasm.wasm", "parquet_wasm_bg.wasm"],
-          matches: ["<all_urls>"],
+      content_security_policy: isFirefox
+        ? "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';"
+        : {
+            extension_pages:
+              "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';",
+          },
+      web_accessible_resources: isFirefox
+        ? ["api-hooks.js", "ai-hooks.js", "sql-wasm.wasm", "parquet_wasm_bg.wasm"]
+        : [
+            {
+              resources: ["api-hooks.js", "ai-hooks.js", "sql-wasm.wasm", "parquet_wasm_bg.wasm"],
+              matches: ["<all_urls>"],
+            },
+          ],
+      // Firefox-specific: browser_specific_settings
+      ...(isFirefox && {
+        browser_specific_settings: {
+          gecko: {
+            id: "pleno-audit@example.com",
+            strict_min_version: "109.0",
+          },
         },
-      ],
+      }),
     };
   },
   vite: () => ({


### PR DESCRIPTION
## Summary
- Phase 4のマルチブラウザ対応としてFirefox MV2ビルドをサポート
- wxt.config.tsでブラウザ別のmanifest設定を追加
- Chrome固有API（scripting）の条件分岐を追加

## 変更内容
- Firefox MV2用のpermissions調整（offscreen, scripting除去）
- browser_specific_settings (gecko) の追加
- CSPとweb_accessible_resourcesのMV2形式対応
- chrome.scripting APIの存在チェック追加

## ビルドコマンド
```bash
# Chrome MV3
pnpm build

# Firefox MV2
pnpm --filter @pleno-audit/extension exec wxt build --browser firefox
```

## Test plan
- [x] Chrome MV3ビルド成功
- [x] Firefox MV2ビルド成功
- [ ] Firefox Developer Editionでの動作確認