### PR TITLE
feat: 軽量脅威DBの追加 (Phase 5)

### DIFF
--- a/packages/threat-intel/package.json
+++ b/packages/threat-intel/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@pleno-audit/threat-intel",
+  "version": "0.1.0",
+  "description": "Lightweight bundled threat intelligence for Pleno Audit",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/threat-intel/src/index.ts
+++ b/packages/threat-intel/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @fileoverview Pleno Audit Threat Intelligence
+ *
+ * Lightweight, bundled threat intelligence for local-only security analysis.
+ * No external network requests - all data is bundled with the extension.
+ */
+
+// Threat Data
+export {
+  HIGH_RISK_TLDS,
+  FINANCIAL_TLDS,
+  PHISHING_PATTERNS,
+  IMPERSONATION_INDICATORS,
+  INFRASTRUCTURE_PATTERNS,
+  getThreatDataVersion,
+  type ThreatIndicator,
+  type ThreatDataVersion,
+} from "./threat-data.js";
+
+// Threat Analyzer
+export {
+  createThreatAnalyzer,
+  DEFAULT_THREAT_ANALYZER_CONFIG,
+  type ThreatAnalyzer,
+  type ThreatAnalyzerConfig,
+  type ThreatAnalysisResult,
+  type ThreatMatch,
+} from "./threat-analyzer.js";

--- a/packages/threat-intel/src/threat-analyzer.ts
+++ b/packages/threat-intel/src/threat-analyzer.ts
@@ -1,0 +1,223 @@
+/**
+ * @fileoverview Threat Analyzer
+ *
+ * Analyzes domains against bundled threat intelligence data.
+ * All processing is local - no network requests.
+ */
+
+import {
+  HIGH_RISK_TLDS,
+  PHISHING_PATTERNS,
+  IMPERSONATION_INDICATORS,
+  INFRASTRUCTURE_PATTERNS,
+  type ThreatIndicator,
+} from "./threat-data.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ThreatMatch {
+  category: "phishing" | "impersonation" | "infrastructure" | "high_risk_tld";
+  description: string;
+  score: number;
+}
+
+export interface ThreatAnalysisResult {
+  domain: string;
+  threatScore: number;
+  riskLevel: "critical" | "high" | "medium" | "low" | "none";
+  matches: ThreatMatch[];
+  hasHighRiskTLD: boolean;
+  timestamp: number;
+}
+
+export interface ThreatAnalyzerConfig {
+  enabled: boolean;
+  minScoreToReport: number;
+  checkHighRiskTLDs: boolean;
+  checkPhishingPatterns: boolean;
+  checkImpersonation: boolean;
+  checkInfrastructure: boolean;
+}
+
+export const DEFAULT_THREAT_ANALYZER_CONFIG: ThreatAnalyzerConfig = {
+  enabled: false, // Disabled by default, requires user consent
+  minScoreToReport: 30,
+  checkHighRiskTLDs: true,
+  checkPhishingPatterns: true,
+  checkImpersonation: true,
+  checkInfrastructure: true,
+};
+
+// ============================================================================
+// Analyzer
+// ============================================================================
+
+/**
+ * Extract TLD from domain
+ */
+function extractTLD(domain: string): string {
+  const parts = domain.toLowerCase().split(".");
+  return parts[parts.length - 1] || "";
+}
+
+/**
+ * Check patterns against domain
+ */
+function checkPatterns(
+  domain: string,
+  patterns: ReadonlyArray<ThreatIndicator>,
+  category: ThreatMatch["category"]
+): ThreatMatch[] {
+  const matches: ThreatMatch[] = [];
+
+  for (const indicator of patterns) {
+    if (indicator.pattern.test(domain)) {
+      matches.push({
+        category,
+        description: indicator.description,
+        score: indicator.score,
+      });
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Calculate risk level from score
+ */
+function scoreToRiskLevel(
+  score: number
+): ThreatAnalysisResult["riskLevel"] {
+  if (score >= 80) return "critical";
+  if (score >= 60) return "high";
+  if (score >= 40) return "medium";
+  if (score >= 20) return "low";
+  return "none";
+}
+
+/**
+ * Create threat analyzer instance
+ */
+export function createThreatAnalyzer(
+  config: ThreatAnalyzerConfig = DEFAULT_THREAT_ANALYZER_CONFIG
+) {
+  let currentConfig = { ...config };
+
+  /**
+   * Update configuration
+   */
+  function updateConfig(updates: Partial<ThreatAnalyzerConfig>): void {
+    currentConfig = { ...currentConfig, ...updates };
+  }
+
+  /**
+   * Get current configuration
+   */
+  function getConfig(): ThreatAnalyzerConfig {
+    return { ...currentConfig };
+  }
+
+  /**
+   * Check if analyzer is enabled
+   */
+  function isEnabled(): boolean {
+    return currentConfig.enabled;
+  }
+
+  /**
+   * Analyze a domain for threat indicators
+   */
+  function analyze(domain: string): ThreatAnalysisResult {
+    const normalizedDomain = domain.toLowerCase().trim();
+    const matches: ThreatMatch[] = [];
+    let threatScore = 0;
+
+    // Check high-risk TLD
+    const tld = extractTLD(normalizedDomain);
+    const hasHighRiskTLD = HIGH_RISK_TLDS.has(tld);
+
+    if (currentConfig.checkHighRiskTLDs && hasHighRiskTLD) {
+      matches.push({
+        category: "high_risk_tld",
+        description: `High-risk TLD: .${tld}`,
+        score: 20,
+      });
+      threatScore += 20;
+    }
+
+    // Check phishing patterns
+    if (currentConfig.checkPhishingPatterns) {
+      const phishingMatches = checkPatterns(
+        normalizedDomain,
+        PHISHING_PATTERNS,
+        "phishing"
+      );
+      matches.push(...phishingMatches);
+      threatScore += phishingMatches.reduce((sum, m) => sum + m.score, 0);
+    }
+
+    // Check impersonation indicators
+    if (currentConfig.checkImpersonation) {
+      const impersonationMatches = checkPatterns(
+        normalizedDomain,
+        IMPERSONATION_INDICATORS,
+        "impersonation"
+      );
+      matches.push(...impersonationMatches);
+      threatScore += impersonationMatches.reduce((sum, m) => sum + m.score, 0);
+    }
+
+    // Check infrastructure patterns
+    if (currentConfig.checkInfrastructure) {
+      const infraMatches = checkPatterns(
+        normalizedDomain,
+        INFRASTRUCTURE_PATTERNS,
+        "infrastructure"
+      );
+      matches.push(...infraMatches);
+      threatScore += infraMatches.reduce((sum, m) => sum + m.score, 0);
+    }
+
+    // Cap score at 100
+    threatScore = Math.min(threatScore, 100);
+
+    return {
+      domain: normalizedDomain,
+      threatScore,
+      riskLevel: scoreToRiskLevel(threatScore),
+      matches,
+      hasHighRiskTLD,
+      timestamp: Date.now(),
+    };
+  }
+
+  /**
+   * Quick check if domain has any threat indicators
+   */
+  function hasThreats(domain: string): boolean {
+    if (!currentConfig.enabled) return false;
+    const result = analyze(domain);
+    return result.threatScore >= currentConfig.minScoreToReport;
+  }
+
+  /**
+   * Batch analyze multiple domains
+   */
+  function analyzeMultiple(domains: string[]): ThreatAnalysisResult[] {
+    return domains.map((domain) => analyze(domain));
+  }
+
+  return {
+    updateConfig,
+    getConfig,
+    isEnabled,
+    analyze,
+    hasThreats,
+    analyzeMultiple,
+  };
+}
+
+export type ThreatAnalyzer = ReturnType<typeof createThreatAnalyzer>;

--- a/packages/threat-intel/src/threat-data.ts
+++ b/packages/threat-intel/src/threat-data.ts
@@ -1,0 +1,210 @@
+/**
+ * @fileoverview Bundled Threat Intelligence Data
+ *
+ * This file contains static threat intelligence data bundled with the extension.
+ * No external network requests are made - all data is local.
+ *
+ * Data sources (public, open-source):
+ * - High-risk TLDs: Based on Spamhaus statistics
+ * - Phishing patterns: Common patterns observed in phishing campaigns
+ * - Brand impersonation: Generic patterns, not specific brand lists
+ *
+ * Last updated: 2025-01
+ */
+
+// ============================================================================
+// High-Risk TLDs
+// ============================================================================
+
+/**
+ * TLDs with historically high abuse rates
+ * Source: Spamhaus statistics, public reports
+ */
+export const HIGH_RISK_TLDS: ReadonlySet<string> = new Set([
+  // Free/cheap TLDs often abused
+  "tk",
+  "ml",
+  "ga",
+  "cf",
+  "gq",
+  // Other high-abuse TLDs
+  "xyz",
+  "top",
+  "work",
+  "click",
+  "link",
+  "info",
+  "online",
+  "site",
+  "club",
+  "icu",
+  "buzz",
+  "rest",
+  "surf",
+  "monster",
+  "uno",
+]);
+
+/**
+ * TLDs commonly used for legitimate financial services
+ * Lower risk when combined with other factors
+ */
+export const FINANCIAL_TLDS: ReadonlySet<string> = new Set([
+  "bank",
+  "insurance",
+  "finance",
+]);
+
+// ============================================================================
+// Suspicious Domain Patterns
+// ============================================================================
+
+/**
+ * Patterns commonly found in phishing domains
+ */
+export const PHISHING_PATTERNS: ReadonlyArray<{
+  pattern: RegExp;
+  description: string;
+  score: number;
+}> = [
+  // Login/account related
+  {
+    pattern: /(?:secure|verify|confirm|update|validate)[_-]?(?:account|login|signin)/i,
+    description: "Login verification pattern",
+    score: 40,
+  },
+  {
+    pattern: /(?:account|login|signin)[_-]?(?:secure|verify|confirm|update)/i,
+    description: "Account security pattern",
+    score: 40,
+  },
+  // Urgency patterns
+  {
+    pattern: /(?:urgent|immediate|suspended|locked|limited)/i,
+    description: "Urgency indicator",
+    score: 25,
+  },
+  // Support/help patterns
+  {
+    pattern: /(?:support|helpdesk|customer)[_-]?(?:center|service|team)/i,
+    description: "Fake support pattern",
+    score: 20,
+  },
+  // Number suffixes (common in bulk phishing)
+  {
+    pattern: /\d{4,}$/,
+    description: "Numeric suffix pattern",
+    score: 15,
+  },
+  // Hyphen abuse
+  {
+    pattern: /-{2,}/,
+    description: "Multiple hyphens",
+    score: 20,
+  },
+  // Long subdomains
+  {
+    pattern: /^[^.]{30,}\./,
+    description: "Very long subdomain",
+    score: 25,
+  },
+];
+
+/**
+ * Brand impersonation indicators (generic patterns)
+ * Note: We don't maintain a list of specific brands to avoid false positives
+ */
+export const IMPERSONATION_INDICATORS: ReadonlyArray<{
+  pattern: RegExp;
+  description: string;
+  score: number;
+}> = [
+  // Common brand-adjacent patterns
+  {
+    pattern: /(?:^|[.-])(?:official|real|genuine|authentic|original)[.-]/i,
+    description: "Authenticity claim in domain",
+    score: 35,
+  },
+  {
+    pattern: /(?:^|[.-])(?:my|your|our|the)[.-]?(?:account|portal|login)/i,
+    description: "Possessive account pattern",
+    score: 25,
+  },
+  // Security theater
+  {
+    pattern: /(?:^|[.-])(?:ssl|https|secure|safe|protected)[.-]/i,
+    description: "Security claim in domain",
+    score: 30,
+  },
+  // Country/region indicators (often used to bypass filters)
+  {
+    pattern: /(?:^|[.-])(?:jp|us|uk|eu|asia)[.-]?(?:login|portal|account)/i,
+    description: "Region-specific portal pattern",
+    score: 20,
+  },
+];
+
+// ============================================================================
+// Malicious Infrastructure Patterns
+// ============================================================================
+
+/**
+ * Patterns indicating potential malicious infrastructure
+ */
+export const INFRASTRUCTURE_PATTERNS: ReadonlyArray<{
+  pattern: RegExp;
+  description: string;
+  score: number;
+}> = [
+  // Random-looking subdomains (often generated)
+  {
+    pattern: /^[a-z0-9]{16,}\./i,
+    description: "Random alphanumeric subdomain",
+    score: 30,
+  },
+  // IP-like patterns in domain
+  {
+    pattern: /\d{1,3}[.-]\d{1,3}[.-]\d{1,3}/,
+    description: "IP-like pattern in domain",
+    score: 25,
+  },
+  // Base64-like patterns
+  {
+    pattern: /[a-z0-9+/]{20,}={0,2}/i,
+    description: "Base64-like pattern",
+    score: 20,
+  },
+  // UUID-like patterns
+  {
+    pattern: /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i,
+    description: "UUID in domain",
+    score: 35,
+  },
+];
+
+// ============================================================================
+// Export Types
+// ============================================================================
+
+export interface ThreatIndicator {
+  pattern: RegExp;
+  description: string;
+  score: number;
+}
+
+export interface ThreatDataVersion {
+  version: string;
+  lastUpdated: string;
+  totalPatterns: number;
+}
+
+export function getThreatDataVersion(): ThreatDataVersion {
+  return {
+    version: "1.0.0",
+    lastUpdated: "2025-01",
+    totalPatterns:
+      PHISHING_PATTERNS.length +
+      IMPERSONATION_INDICATORS.length +
+      INFRASTRUCTURE_PATTERNS.length,
+  };
+}

--- a/packages/threat-intel/tsconfig.json
+++ b/packages/threat-intel/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,12 @@ importers:
         specifier: workspace:*
         version: link:../detectors
 
+  packages/threat-intel:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/typosquat: {}
 
 packages:


### PR DESCRIPTION
## Summary
Phase 5の「軽量脅威DB」をバンドル形式で実装

- 新規パッケージ: `@pleno-audit/threat-intel`
- 外部通信なし - すべてのデータがバンドルされている
- プライバシーポリシーに準拠

## 実装内容

### 脅威データ (threat-data.ts)
- **高リスクTLD**: Spamhaus統計に基づく悪用率の高いTLD
- **フィッシングパターン**: ログイン/認証関連の疑わしいパターン
- **ブランド偽装指標**: 真正性を主張するドメインパターン
- **インフラパターン**: ランダム文字列、UUID等の疑わしいパターン

### 脅威アナライザー (threat-analyzer.ts)
- `createThreatAnalyzer()`: 分析器インスタンス作成
- `analyze(domain)`: ドメインの脅威分析
- `hasThreats(domain)`: クイックチェック
- スコアベースのリスク評価（critical/high/medium/low/none）

## Test plan
- [x] パッケージビルド成功
- [ ] 拡張機能との統合テスト