### PR TITLE
feat: 脅威インテリジェンス統合

### DIFF
--- a/app/extension/package.json
+++ b/app/extension/package.json
@@ -22,6 +22,7 @@
     "@pleno-audit/security-graph": "workspace:*",
     "@pleno-audit/integrations": "workspace:*",
     "@pleno-audit/storage": "workspace:*",
+    "@pleno-audit/threat-intel": "workspace:*",
     "hono": "^4.11.4",
     "lucide-preact": "^0.562.0",
     "preact": "^10.28.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@pleno-audit/storage':
         specifier: workspace:*
         version: link:../../packages/storage
+      '@pleno-audit/threat-intel':
+        specifier: workspace:*
+        version: link:../../packages/threat-intel
       hono:
         specifier: ^4.11.4
         version: 4.11.4


### PR DESCRIPTION
## Summary
#58で追加した軽量脅威DBを拡張機能のtyposquat検出と統合

## 変更内容
- `@pleno-audit/threat-intel` パッケージを拡張機能に追加
- background.tsでthreat analyzerを初期化
- typosquatチェック時に脅威インテリジェンス分析を実行
- 高リスクドメインをthreat_intel_matchイベントとして記録

## 動作
1. ドメインのtyposquatチェック実行
2. 同時にthreat-intelで脅威分析
3. スコア40以上でイベントログに記録

## Test plan
- [x] ビルド成功（background.js: 85KB → 88KB）