### PR TITLE
feat: predictive-analysisパッケージを拡張機能に統合

### DIFF
--- a/app/extension/package.json
+++ b/app/extension/package.json
@@ -23,6 +23,7 @@
     "@pleno-audit/integrations": "workspace:*",
     "@pleno-audit/storage": "workspace:*",
     "@pleno-audit/threat-intel": "workspace:*",
+    "@pleno-audit/predictive-analysis": "workspace:*",
     "hono": "^4.11.4",
     "lucide-preact": "^0.562.0",
     "preact": "^10.28.2",

--- a/packages/extension-runtime/package.json
+++ b/packages/extension-runtime/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@pleno-audit/detectors": "workspace:*",
-    "@pleno-audit/csp": "workspace:*"
+    "@pleno-audit/csp": "workspace:*",
+    "@pleno-audit/predictive-analysis": "workspace:*"
   }
 }

--- a/packages/extension-runtime/src/storage-types.ts
+++ b/packages/extension-runtime/src/storage-types.ts
@@ -9,6 +9,7 @@ import type {
   NRDConfig,
 } from "@pleno-audit/detectors";
 import type { CSPConfig, CSPReport } from "@pleno-audit/csp";
+import type { ForecastConfig } from "@pleno-audit/predictive-analysis";
 
 export interface ExtensionMonitorConfig {
   enabled: boolean;
@@ -97,6 +98,7 @@ export interface StorageData {
   dataRetentionConfig?: DataRetentionConfig;
   detectionConfig?: DetectionConfig;
   blockingConfig?: BlockingConfig;
+  forecastConfig?: ForecastConfig;
 }
 
 export type {
@@ -109,4 +111,5 @@ export type {
   NRDConfig,
   DataRetentionConfig,
   DetectionConfig,
+  ForecastConfig,
 };

--- a/packages/extension-runtime/src/storage.ts
+++ b/packages/extension-runtime/src/storage.ts
@@ -14,6 +14,7 @@ import type {
   DataRetentionConfig,
   DetectionConfig,
   BlockingConfig,
+  ForecastConfig,
 } from "./storage-types.js";
 import {
   DEFAULT_DATA_RETENTION_CONFIG,
@@ -25,6 +26,7 @@ import { DEFAULT_NRD_CONFIG } from "@pleno-audit/detectors";
 import { DEFAULT_EXTENSION_MONITOR_CONFIG } from "./extension-monitor.js";
 import { DEFAULT_CSP_CONFIG } from "@pleno-audit/csp";
 import { DEFAULT_AI_MONITOR_CONFIG } from "@pleno-audit/detectors";
+import { DEFAULT_FORECAST_CONFIG } from "@pleno-audit/predictive-analysis";
 
 const STORAGE_KEYS = [
   "services",
@@ -39,6 +41,7 @@ const STORAGE_KEYS = [
   "dataRetentionConfig",
   "detectionConfig",
   "blockingConfig",
+  "forecastConfig",
 ] as const;
 type StorageKey = (typeof STORAGE_KEYS)[number];
 
@@ -73,6 +76,8 @@ export async function getStorage(): Promise<StorageData> {
       (result.detectionConfig as DetectionConfig) || DEFAULT_DETECTION_CONFIG,
     blockingConfig:
       (result.blockingConfig as BlockingConfig) || DEFAULT_BLOCKING_CONFIG,
+    forecastConfig:
+      (result.forecastConfig as ForecastConfig) || DEFAULT_FORECAST_CONFIG,
   };
 }
 
@@ -97,6 +102,7 @@ export async function getStorageKey<K extends StorageKey>(
     dataRetentionConfig: DEFAULT_DATA_RETENTION_CONFIG,
     detectionConfig: DEFAULT_DETECTION_CONFIG,
     blockingConfig: DEFAULT_BLOCKING_CONFIG,
+    forecastConfig: DEFAULT_FORECAST_CONFIG,
   };
   return (result[key] as StorageData[K]) ?? defaults[key];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@pleno-audit/policy-engine':
         specifier: workspace:*
         version: link:../../packages/policy-engine
+      '@pleno-audit/predictive-analysis':
+        specifier: workspace:*
+        version: link:../../packages/predictive-analysis
       '@pleno-audit/risk-prioritization':
         specifier: workspace:*
         version: link:../../packages/risk-prioritization
@@ -229,6 +232,9 @@ importers:
       '@pleno-audit/detectors':
         specifier: workspace:*
         version: link:../detectors
+      '@pleno-audit/predictive-analysis':
+        specifier: workspace:*
+        version: link:../predictive-analysis
 
   packages/identity-security:
     devDependencies:


### PR DESCRIPTION
## Summary

@pleno-audit/predictive-analysis パッケージを拡張機能に統合し、リスク予測機能を実装しました。

- 過去7日間のセキュリティイベントから自動的にリスク傾向を分析
- 線形回帰とZ-scoreを使用した異常検知
- ダッシュボードのTimelineTabにリスク予測セクションを追加
- 現在のリスクレベル、予測リスク、トレンド、信頼度を表示
- 異常検知結果をアラートとして表示

すべての分析はローカルで完結し、外部通信なし。

## Changes

### Backend (background.ts)
- `getRiskForecaster()`: リスク予測エンジンの初期化
- `getRiskForecast()`: イベントストアからセキュリティイベントを読み込んで予測を生成
- メッセージハンドラー: GET_RISK_FORECAST, GET_FORECAST_CONFIG, SET_FORECAST_CONFIG

### Frontend (TimelineTab.tsx)
- リスク予測セクションを追加
- 4つのメトリクス表示: 現在のリスク、予測リスク、トレンド、信頼度
- 警告セクション: 生成された警告を重大度別に表示

### Storage (storage.ts, storage-types.ts)
- StorageData に forecastConfig フィールドを追加
- DEFAULT_FORECAST_CONFIG を参照

## Test Plan

- [x] ビルドが成功し、型エラーがないことを確認
- [x] 拡張機能が正常に起動することを確認
- [ ] ダッシュボードを開いてリスク予測セクションが表示されることを確認
- [ ] リスク予測の計算が正確に実行されることを確認
- [ ] 警告が正しく表示されることを確認