### PR TITLE
fix: unify popup tab UI styles

### DIFF
--- a/app/extension/entrypoints/popup/components/AIPromptList.tsx
+++ b/app/extension/entrypoints/popup/components/AIPromptList.tsx
@@ -71,7 +71,7 @@ function PromptCard({
           cursor: "pointer",
           display: "flex",
           flexDirection: showProvider ? "column" : "row",
-          gap: "6px",
+          gap: "3px",
           alignItems: showProvider ? "stretch" : "center",
         }}
       >

--- a/app/extension/entrypoints/popup/components/NetworkList.tsx
+++ b/app/extension/entrypoints/popup/components/NetworkList.tsx
@@ -27,8 +27,8 @@ export function NetworkList({ requests }: Props) {
           <thead>
             <tr>
               <th style={styles.tableHeader}>時間</th>
-              <th style={styles.tableHeader}>Type</th>
               <th style={styles.tableHeader}>ドメイン</th>
+              <th style={styles.tableHeader}>Type</th>
             </tr>
           </thead>
           <tbody>
@@ -40,10 +40,10 @@ export function NetworkList({ requests }: Props) {
                   </span>
                 </td>
                 <td style={styles.tableCell}>
-                  <Badge>{r.initiator}</Badge>
+                  <code style={styles.code}>{r.domain}</code>
                 </td>
                 <td style={styles.tableCell}>
-                  <code style={styles.code}>{r.domain}</code>
+                  <Badge>{r.initiator}</Badge>
                 </td>
               </tr>
             ))}

--- a/app/extension/entrypoints/popup/components/RequestsTab.tsx
+++ b/app/extension/entrypoints/popup/components/RequestsTab.tsx
@@ -15,7 +15,7 @@ export function RequestsTab({ violations, networkRequests }: RequestsTabProps) {
   const hasData = violations.length > 0 || networkRequests.length > 0;
 
   return (
-    <div>
+    <div style={styles.tabContent}>
       {!hasData && (
         <div style={styles.section}>
           <p style={styles.emptyText}>
@@ -31,18 +31,18 @@ export function RequestsTab({ violations, networkRequests }: RequestsTabProps) {
       )}
 
       {networkRequests.length > 0 && (
-        <div style={styles.divider}>
+        <div>
           <NetworkList requests={networkRequests} />
         </div>
       )}
 
       {hasData && (
-        <div style={styles.divider}>
+        <div>
           <PolicyGenerator violations={violations} />
         </div>
       )}
 
-      <div style={styles.divider}>
+      <div>
         <CSPSettings />
       </div>
     </div>

--- a/app/extension/entrypoints/popup/components/ServicesTab.tsx
+++ b/app/extension/entrypoints/popup/components/ServicesTab.tsx
@@ -11,6 +11,7 @@ import {
   type SortType,
 } from "../utils/serviceAggregator";
 import { DetectionSettings } from "./DetectionSettings";
+import { usePopupStyles } from "../styles";
 
 interface ServicesTabProps {
   services: DetectedService[];
@@ -96,6 +97,7 @@ function formatRelativeTime(timestamp: number): string {
 
 export function ServicesTab({ services, violations, networkRequests }: ServicesTabProps) {
   const { colors } = useTheme();
+  const popupStyles = usePopupStyles();
   const [unifiedServices, setUnifiedServices] = useState<UnifiedService[]>([]);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
@@ -135,11 +137,6 @@ export function ServicesTab({ services, violations, networkRequests }: ServicesT
   }
 
   const styles = {
-    container: {
-      display: "flex",
-      flexDirection: "column" as const,
-      gap: "8px",
-    },
     header: {
       fontSize: "12px",
       fontWeight: 500,
@@ -271,14 +268,14 @@ export function ServicesTab({ services, violations, networkRequests }: ServicesT
 
   if (sortedServices.length === 0) {
     return (
-      <div style={styles.container}>
+      <div style={popupStyles.tabContent}>
         <p style={styles.emptyText}>サービスはまだ検出されていません</p>
       </div>
     );
   }
 
   return (
-    <div style={styles.container}>
+    <div style={popupStyles.tabContent}>
       <div style={styles.header}>
         <span>サービス ({sortedServices.length})</span>
         <select

--- a/app/extension/entrypoints/popup/components/SessionsTab.tsx
+++ b/app/extension/entrypoints/popup/components/SessionsTab.tsx
@@ -34,15 +34,15 @@ export function SessionsTab({ events, aiPrompts }: SessionsTabProps) {
   }
 
   return (
-    <div>
+    <div style={styles.tabContent}>
       {hasAIPrompts && (
-        <div style={styles.divider}>
+        <div>
           <AIPromptList prompts={aiPrompts} />
         </div>
       )}
 
       {hasEvents && (
-        <div style={styles.divider}>
+        <div>
           <EventLogList
             events={events}
             filterTypes={SESSION_EVENT_TYPES}

--- a/app/extension/entrypoints/popup/components/ViolationList.tsx
+++ b/app/extension/entrypoints/popup/components/ViolationList.tsx
@@ -63,7 +63,7 @@ function ViolationCard({
           cursor: "pointer",
           display: "flex",
           alignItems: "center",
-          gap: "8px",
+          gap: "3px",
         }}
       >
         <span style={{ fontFamily: "monospace", fontSize: "11px", color: colors.textSecondary }}>

--- a/app/extension/entrypoints/popup/styles.ts
+++ b/app/extension/entrypoints/popup/styles.ts
@@ -97,9 +97,7 @@ export function createStyles(colors: ThemeColors): Record<string, CSSProperties>
       background: colors.bgSecondary,
     },
 
-    section: {
-      marginBottom: "16px",
-    },
+    section: {},
 
     sectionTitle: {
       fontSize: "12px",
@@ -113,8 +111,7 @@ export function createStyles(colors: ThemeColors): Record<string, CSSProperties>
       background: colors.bgPrimary,
       border: `1px solid ${colors.border}`,
       borderRadius: "8px",
-      padding: "16px",
-      marginBottom: "12px",
+      padding: "10px 12px",
     },
 
     table: {
@@ -289,6 +286,12 @@ export function createStyles(colors: ThemeColors): Record<string, CSSProperties>
       borderTop: `1px solid ${colors.border}`,
       marginTop: "16px",
       paddingTop: "16px",
+    },
+
+    tabContent: {
+      display: "flex",
+      flexDirection: "column" as const,
+      gap: "8px",
     },
 
     statsGrid: {


### PR DESCRIPTION
## Summary
- Services/Sessions/Requestsタブで共通のtabContentスタイル(gap: 8px)を使用
- カードのpadding(10px 12px)を全タブで統一
- NetworkListの列順序をEventLogと統一(時間→ドメイン→Type)

## Test plan
- [x] ビルド成功確認済み