### PR TITLE
feat: add debug command to test extension request detection

### DIFF
--- a/app/debugger/src/commands/browser.ts
+++ b/app/debugger/src/commands/browser.ts
@@ -28,3 +28,32 @@ browserCommand
       process.exit(1);
     }
   });
+
+browserCommand
+  .command("test-extension-request")
+  .description("Send a test request to verify webRequest listener is working")
+  .action(async () => {
+    try {
+      const client = await getExtensionClient();
+      const response = await client.send("DEBUG_TEST_EXTENSION_REQUEST", {});
+
+      if (response.success) {
+        console.log("Test request sent successfully!");
+        console.log(`URL: ${response.data?.url}`);
+        console.log(`Status: ${response.data?.status}`);
+        console.log(`Extension ID: ${response.data?.extensionId}`);
+        console.log("\nCheck extension_request events with:");
+        console.log("  pleno-debug events list --type extension_request");
+      } else {
+        console.error(`Failed: ${response.error}`);
+        process.exit(1);
+      }
+
+      client.disconnect();
+    } catch (error) {
+      console.error(
+        `Error: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+      process.exit(1);
+    }
+  });

--- a/app/extension/entrypoints/background.ts
+++ b/app/extension/entrypoints/background.ts
@@ -2120,6 +2120,31 @@ async function handleDebugBridgeForward(
         return { success: true, data: { tabId: tab.id, url: tab.url || url } };
       }
 
+      case "DEBUG_TEST_EXTENSION_REQUEST": {
+        // Test if webRequest listener is capturing extension-originated requests
+        // This request should be captured by the extension monitor if working correctly
+        try {
+          const testUrl = "https://httpbin.org/get?test=extension-monitor";
+          logger.debug("Sending test request to verify webRequest listener:", testUrl);
+          const response = await fetch(testUrl);
+          const status = response.status;
+          return {
+            success: true,
+            data: {
+              message: "Test request sent. Check extension_request events.",
+              url: testUrl,
+              status,
+              extensionId: chrome.runtime.id,
+            },
+          };
+        } catch (error) {
+          return {
+            success: false,
+            error: `Test request failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+          };
+        }
+      }
+
       default:
         return { success: false, error: `Unknown debug message type: ${type}` };
     }


### PR DESCRIPTION
## Summary
- webRequest listenerが拡張機能からのリクエストを検出できるかテストするデバッグコマンドを追加
- `pleno-debug browser test-extension-request` で実行可能
- httpbin.orgにテストリクエストを送信し、extension_requestイベントとして検出されるか確認

## Test plan
- [ ] `pnpm --filter @pleno-audit/debugger start browser test-extension-request` を実行
- [ ] `pnpm --filter @pleno-audit/debugger start events list --type extension_request` でイベント確認