### PR TITLE
fix: auto kill process using debug port on dev start

### DIFF
--- a/app/debugger/src/commands/install.ts
+++ b/app/debugger/src/commands/install.ts
@@ -11,7 +11,11 @@ export const installCommand = new Command("server")
     console.log("\nPress Ctrl+C to stop\n");
 
     // Dynamic import to avoid starting server on CLI load
-    const { getDebugServer } = await import("../server.js");
+    const { getDebugServer, killPortProcess } = await import("../server.js");
+
+    // Kill existing process if port is in use
+    await killPortProcess(port);
+
     const server = getDebugServer();
 
     server.on("extension-connected", () => {


### PR DESCRIPTION
## Summary
- `pnpm dev` 実行時にポート9222が占有されていたら自動的にプロセスをkillする処理を追加
- `killPortProcess()` 関数を追加（lsofでPID特定→kill -9で終了）

## Test plan
- [x] ポート9222が占有されている状態で `pnpm dev` を実行し、自動killされることを確認
- [x] 型チェック通過