### PR TITLE
feat: increase popup display limit from 50 to 20000

### DIFF
--- a/app/extension/entrypoints/popup/App.tsx
+++ b/app/extension/entrypoints/popup/App.tsx
@@ -222,7 +222,7 @@ function PopupContent() {
                   ...styles.tabCount,
                   ...(tab === t.key ? styles.tabCountActive : styles.tabCountInactive),
                 }}>
-                  {count > 50 ? "50+" : count}
+                  {count > 20000 ? "20000+" : count}
                 </span>
               )}
             </button>

--- a/app/extension/entrypoints/popup/components/AIPromptList.tsx
+++ b/app/extension/entrypoints/popup/components/AIPromptList.tsx
@@ -23,9 +23,9 @@ export function AIPromptList({ prompts }: Props) {
 
   return (
     <div style={styles.section}>
-      <h3 style={styles.sectionTitle}>AIプロンプト ({prompts.length > 50 ? "50+" : prompts.length})</h3>
+      <h3 style={styles.sectionTitle}>AIプロンプト ({prompts.length > 20000 ? "20000+" : prompts.length})</h3>
       <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-        {prompts.slice(0, 50).map((prompt) => (
+        {prompts.slice(0, 20000).map((prompt) => (
           <PromptCard
             key={prompt.id}
             prompt={prompt}

--- a/app/extension/entrypoints/popup/components/EventLog.tsx
+++ b/app/extension/entrypoints/popup/components/EventLog.tsx
@@ -27,7 +27,7 @@ export function EventLogList({ events, filterTypes, title = "イベント" }: Pr
 
   return (
     <div style={styles.section}>
-      <h3 style={styles.sectionTitle}>{title} ({filteredEvents.length > 50 ? "50+" : filteredEvents.length})</h3>
+      <h3 style={styles.sectionTitle}>{title} ({filteredEvents.length > 20000 ? "20000+" : filteredEvents.length})</h3>
       <div style={styles.card}>
         <table style={styles.table}>
           <thead>
@@ -38,7 +38,7 @@ export function EventLogList({ events, filterTypes, title = "イベント" }: Pr
             </tr>
           </thead>
           <tbody>
-            {filteredEvents.slice(0, 50).map((event) => (
+            {filteredEvents.slice(0, 20000).map((event) => (
               <EventRow key={event.id} event={event} styles={styles} colors={colors} />
             ))}
           </tbody>

--- a/app/extension/entrypoints/popup/components/NetworkList.tsx
+++ b/app/extension/entrypoints/popup/components/NetworkList.tsx
@@ -21,7 +21,7 @@ export function NetworkList({ requests }: Props) {
 
   return (
     <div style={styles.section}>
-      <h3 style={styles.sectionTitle}>ネットワーク ({requests.length > 50 ? "50+" : requests.length})</h3>
+      <h3 style={styles.sectionTitle}>ネットワーク ({requests.length > 20000 ? "20000+" : requests.length})</h3>
       <div style={styles.card}>
         <table style={styles.table}>
           <thead>
@@ -32,7 +32,7 @@ export function NetworkList({ requests }: Props) {
             </tr>
           </thead>
           <tbody>
-            {requests.slice(0, 50).map((r, i) => (
+            {requests.slice(0, 20000).map((r, i) => (
               <tr key={i} style={styles.tableRow}>
                 <td style={styles.tableCell}>
                   <span style={{ fontFamily: "monospace", fontSize: "11px", color: colors.textSecondary }}>

--- a/app/extension/entrypoints/popup/components/ViolationList.tsx
+++ b/app/extension/entrypoints/popup/components/ViolationList.tsx
@@ -20,9 +20,9 @@ export function ViolationList({ violations }: ViolationProps) {
 
   return (
     <div style={styles.section}>
-      <h3 style={styles.sectionTitle}>CSP違反 ({violations.length > 50 ? "50+" : violations.length})</h3>
+      <h3 style={styles.sectionTitle}>CSP違反 ({violations.length > 20000 ? "20000+" : violations.length})</h3>
       <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-        {violations.slice(0, 50).map((v, i) => {
+        {violations.slice(0, 20000).map((v, i) => {
           const id = `${v.timestamp}-${i}`;
           return (
             <ViolationCard


### PR DESCRIPTION
## 概要

popupのリスト表示件数上限を**50件から20000件**に変更しました。

## 変更内容

以下のコンポーネントで表示制限を拡大：
- NetworkList: ネットワークリクエスト表示
- EventLog: イベントログ表示
- AIPromptList: AIプロンプト表示
- ViolationList: CSP違反表示
- App: タブナビゲーションのカウント表示

## テスト

- ファイルの修正を確認済み
- `pnpm build`で正常にビルド完了
- ビルト出力に20000が4箇所含まれることを確認