### PR TITLE
feat: add pleno-battacker to releases and update README

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -26,13 +26,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build extension
-        run: pnpm build
+      - name: Build extensions
+        run: |
+          pnpm build
+          pnpm -C app/pleno-battacker build
 
-      - name: Create zip artifact
+      - name: Create zip artifacts
         run: |
           cd app/extension/dist/chrome-mv3
-          zip -r ../../../../extension-canary.zip .
+          zip -r ../../../../pleno-audit-canary.zip .
+          cd ../../../../app/pleno-battacker/dist/chrome-mv3
+          zip -r ../../../../pleno-battacker-canary.zip .
 
       - name: Get version
         id: version
@@ -47,7 +51,9 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Canary ${{ steps.version.outputs.tag }}
-          files: extension-canary.zip
+          files: |
+            pleno-audit-canary.zip
+            pleno-battacker-canary.zip
           prerelease: true
           generate_release_notes: true
           make_latest: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build extension
-        run: pnpm build
+      - name: Build extensions
+        run: |
+          pnpm build
+          pnpm -C app/pleno-battacker build
 
-      - name: Create zip artifact
+      - name: Create zip artifacts
         run: |
           cd app/extension/dist/chrome-mv3
-          zip -r ../../../../extension.zip .
+          zip -r ../../../../pleno-audit.zip .
+          cd ../../../../app/pleno-battacker/dist/chrome-mv3
+          zip -r ../../../../pleno-battacker.zip .
 
       - name: Get version
         id: version
@@ -46,7 +50,9 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}
-          files: extension.zip
+          files: |
+            pleno-audit.zip
+            pleno-battacker.zip
           generate_release_notes: true
           make_latest: true
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,26 @@
 
 Browserを通してアクセスするWebサービスの利用状況を可視化し、プライバシーリスクを管理するChrome拡張機能（CASB/Browser Security）です。
 
+## インストール
+
+### Chrome拡張機能として導入
+
+1. [Releases](https://github.com/HikaruEgashira/pleno-audit/releases)から最新版をダウンロード
+   - **pleno-audit.zip**: メイン拡張機能（CASB/Browser Security）
+   - **pleno-battacker.zip**: 防御耐性テストツール
+2. ダウンロードしたzipファイルを展開
+3. Chrome で `chrome://extensions` を開く
+4. 右上の「デベロッパーモード」を有効にする
+5. 「パッケージ化されていない拡張機能を読み込む」をクリック
+6. 展開したフォルダを選択
+
+### 開発版（Canary）
+
+開発中の最新機能を試す場合は、[Canary Releases](https://github.com/HikaruEgashira/pleno-audit/releases?q=canary&expanded=true)からダウンロードできます。
+
 ## Features
+
+### Pleno Audit（メイン拡張機能）
 
 - Local First: すべてのデータ処理はブラウザ内で完結します。外部DBも用いません
 - Shadow IT
@@ -14,6 +33,18 @@ Browserを通してアクセスするWebサービスの利用状況を可視化�
     - Typosquatting検出
 - Malware
     - CSP Audit: Content Security Policy違反の検出・レポート・ポリシー生成
+
+### Pleno Battacker（防御耐性テストツール）
+
+ブラウザの防御機能がどの程度有効かをテストするツールです。
+
+- 5つの攻撃カテゴリで防御力を評価
+  - Network (25%): 安全でない接続の検出
+  - Phishing (25%): フィッシング対策の検出
+  - ClientSide (20%): XSS等のクライアントサイド攻撃対策
+  - Extension (15%): 拡張機能の権限管理
+  - Download (15%): ダウンロード保護
+- 総合防御スコアを可視化
 
 ## Screenshots
 


### PR DESCRIPTION
## Summary
- pleno-battackerをリリース成果物に追加
- extension.zip → pleno-audit.zip にリネーム（canaryも同様）
- READMEにインストール手順を追記
- Pleno Battackerの説明を追加

## Changes
- `.github/workflows/release.yml`: pleno-battackerビルド追加、zip名変更
- `.github/workflows/canary-release.yml`: 同様の変更
- `README.md`: インストール手順、Pleno Battacker説明追加

## Test plan
- [x] 両拡張機能のビルド成功を確認
- [ ] canaryリリースで成果物が正しく作成されることを確認