### PR TITLE
fix: cleanup WXT Chrome processes on dev exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "DEBUG_PORT=9223 concurrently -n debug,battacker-build,ext,logs -c blue,magenta,green,yellow \"pnpm -C app/debugger start server\" \"pnpm -C app/pleno-battacker build\" \"sleep 3 && pnpm -C app/extension dev\" \"sleep 3 && pnpm -C app/debugger start logs\"",
+    "dev": "DEBUG_PORT=9223 pnpm -C app/pleno-battacker build && DEBUG_PORT=9223 concurrently --kill-others -n debug,ext,logs -c blue,green,yellow \"pnpm -C app/debugger start server\" \"sleep 2 && pnpm -C app/extension dev\" \"sleep 2 && pnpm -C app/debugger start logs\"; pkill -f 'chrome.*tmp-web-ext' 2>/dev/null || true",
     "dev:ext": "pnpm -C app/extension dev",
     "build": "pnpm -C app/extension build",
     "server": "pnpm -C app/server start",


### PR DESCRIPTION
- Add --kill-others to concurrently for proper shutdown
- Run pkill after concurrently exits to cleanup Chrome processes
- Build battacker before starting dev to avoid premature exit