### PR TITLE
fix: simplify extension-debug-guide

### DIFF
--- a/.claude/commands/extension-debug-guide.md
+++ b/.claude/commands/extension-debug-guide.md
@@ -1,24 +1,24 @@
-Chrome拡張機能の動作確認を行います。
+Chrome拡張機能のデバッグ手順ガイドです。
 
-## テスト対象: $ARGUMENTS
+## デバッグの流れ
 
 ### 1. 開発環境を起動
 ```bash
 pnpm dev
 ```
+WXTが専用プロファイル(.wxt-dev)でChromeを起動します。
 
 ### 2. 接続確認
 ```bash
 DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start status
 ```
-期待: Status: Connected, Dev mode: yes
 
-### 3. テストURLを開く
+### 3. URLを開く
 ```bash
-DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start browser open $ARGUMENTS
+DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start browser open <url>
 ```
 
-### 4. ログを確認
+### 4. ログ監視
 ```bash
 DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start logs
 ```
@@ -26,13 +26,8 @@ DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start logs
 ### 5. 終了
 Ctrl+C（自動クリーンアップ）
 
-## 確認ポイント
-- [ ] 開発環境が正常に起動
-- [ ] 拡張機能が接続される
-- [ ] ログにエラーがない
-- [ ] 終了時にプロセスがクリーンアップ
-
 ## トラブルシューティング
 ```bash
-pnpm dev:stop  # プロセスが残っている場合
+pnpm dev:stop                          # プロセス停止
+lsof -i :9223 -t | xargs kill -9       # ポート解放
 ```


### PR DESCRIPTION
引数なしの一般的なデバッグガイドに変更