### PR TITLE
fix: framer-motionに変更（React 18互換性）

### DIFF
--- a/app/battacker-web/package.json
+++ b/app/battacker-web/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@pleno-audit/battacker": "workspace:*",
-    "motion": "^12.0.0",
+    "framer-motion": "^11.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/app/battacker-web/src/App.tsx
+++ b/app/battacker-web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { motion } from "motion/react";
+import { motion } from "framer-motion";
 import type { DefenseScore, CategoryScore, TestResult } from "@pleno-audit/battacker";
 import { CATEGORY_LABELS } from "@pleno-audit/battacker";
 import { useBattacker } from "./hooks/useBattacker";

--- a/app/battacker-web/src/components/CyberGauge.tsx
+++ b/app/battacker-web/src/components/CyberGauge.tsx
@@ -1,4 +1,4 @@
-import { motion } from "motion/react";
+import { motion } from "framer-motion";
 
 interface CyberGaugeProps {
   value: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,9 @@ importers:
       '@pleno-audit/battacker':
         specifier: workspace:*
         version: link:../../packages/battacker
-      motion:
-        specifier: ^12.0.0
-        version: 12.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      framer-motion:
+        specifier: ^11.0.0
+        version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -5089,15 +5089,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  framer-motion@12.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      motion-dom: 12.26.2
-      motion-utils: 12.24.10
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   framer-motion@12.26.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       motion-dom: 12.26.2
@@ -5664,14 +5655,6 @@ snapshots:
   motion-utils@11.18.1: {}
 
   motion-utils@12.24.10: {}
-
-  motion@12.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      framer-motion: 12.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   motion@12.26.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:


### PR DESCRIPTION
motion/reactはReact 19用。React 18ではframer-motionを使用する必要がある。