### PR TITLE
feat(battacker): add content script for page-context test execution

### DIFF
--- a/app/pleno-battacker/entrypoints/content.ts
+++ b/app/pleno-battacker/entrypoints/content.ts
@@ -1,0 +1,54 @@
+import { createLogger } from "@pleno-audit/extension-runtime";
+import {
+  allAttacks,
+  calculateDefenseScore,
+  runAllTests,
+  type DefenseScore,
+} from "@pleno-audit/battacker";
+
+const logger = createLogger("battacker-content");
+
+interface BattackerMessage {
+  type: "BATTACKER_RUN_TESTS";
+}
+
+export default defineContentScript({
+  matches: ["<all_urls>"],
+  runAt: "document_idle",
+  main() {
+    logger.debug("Content script loaded");
+
+    chrome.runtime.onMessage.addListener(
+      (
+        message: BattackerMessage,
+        _sender: chrome.runtime.MessageSender,
+        sendResponse: (response: DefenseScore | { error: string }) => void,
+      ) => {
+        if (message.type === "BATTACKER_RUN_TESTS") {
+          logger.info("Running tests in page context...");
+          executeTests().then(sendResponse);
+          return true;
+        }
+        return false;
+      },
+    );
+  },
+});
+
+async function executeTests(): Promise<DefenseScore | { error: string }> {
+  try {
+    logger.info(`Starting ${allAttacks.length} attack simulations...`);
+
+    const results = await runAllTests(allAttacks, (completed, total, current) => {
+      logger.debug(`Progress: ${completed}/${total} - ${current.name}`);
+    });
+
+    const score = calculateDefenseScore(results);
+    logger.info(`Tests complete. Score: ${score.totalScore} (${score.grade})`);
+
+    return score;
+  } catch (error) {
+    logger.error("Test execution error:", error);
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/app/pleno-battacker/wxt.config.ts
+++ b/app/pleno-battacker/wxt.config.ts
@@ -4,6 +4,10 @@ import preact from "@preact/preset-vite";
 export default defineConfig({
   // Use separate output dir for dev to avoid conflicts with manually loaded extensions
   outDir: process.env.DEBUG_PORT ? ".wxt-dev" : "dist",
+  webExt: {
+    startUrls: ["https://example.com"],
+    chromiumArgs: ["--remote-debugging-port=9223"],
+  },
   vite: () => ({
     plugins: [preact()],
     esbuild: {
@@ -30,6 +34,7 @@ export default defineConfig({
       "history",
       "scripting",
       "management",
+      "activeTab",
     ],
     host_permissions: ["<all_urls>"],
   },


### PR DESCRIPTION
## Summary

- Content Scriptを追加し、ページコンテキストで攻撃シミュレーションを実行
- Service Workerでは検出イベントやlocalStorageにアクセスできないため、Content Scriptにテスト実行を委譲する方式に変更
- `activeTab`権限を追加

## Test plan

- [x] example.comでテスト実行を確認（Score: 17, Grade: F, Categories: 17）
- [x] ブラウザ内部ページ（chrome://）では適切なエラーメッセージを表示