### PR TITLE
fix: use chromiumArgs for battacker autoload in dev

### DIFF
--- a/app/extension/wxt.config.ts
+++ b/app/extension/wxt.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig } from "wxt";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const battackerPath = resolve(__dirname, "../pleno-battacker/dist/chrome-mv3");
 
 export default defineConfig({
   srcDir: ".",
@@ -7,7 +12,7 @@ export default defineConfig({
   imports: false,
   webExt: {
     startUrls: ["https://example.com"],
-    args: [`--load-extension=../pleno-battacker/${process.env.DEBUG_PORT ? ".wxt-dev" : "dist"}/chrome-mv3`],
+    chromiumArgs: [`--load-extension=${battackerPath}`],
   },
   manifest: (env) => {
     const isDev = env.mode === "development";


### PR DESCRIPTION
## Summary
- WXT開発環境でpleno-battackerを自動ロードする設定を修正
- `webExt.args`を`webExt.chromiumArgs`に変更（WXTの正しい設定方法）
- 相対パスから絶対パスへ変更（`import.meta.url`使用）

## Test plan
- [x] `pnpm dev`で開発環境を起動
- [x] Chromeプロセスの引数に`--load-extension`が含まれていることを確認
- [x] 絶対パスでbattackerのdist/chrome-mv3が指定されていることを確認