### PR TITLE
fix: add default_icon to battacker extension action

### DIFF
--- a/app/battacker-extension/wxt.config.ts
+++ b/app/battacker-extension/wxt.config.ts
@@ -25,6 +25,14 @@ export default defineConfig({
       48: "icon-48.png",
       128: "icon-128.png",
     },
+    action: {
+      default_icon: {
+        16: "icon-16.png",
+        32: "icon-32.png",
+        48: "icon-48.png",
+        128: "icon-128.png",
+      },
+    },
     permissions: [
       "storage",
       "alarms",


### PR DESCRIPTION
## Summary
- battacker拡張機能のツールバーアイコンが表示されない問題を修正
- `action.default_icon`をmanifestに追加

## Test plan
- [ ] 拡張機能を再読み込みしてツールバーアイコンが表示されることを確認