### PR TITLE
fix(battacker-web): remove detected field references

### DIFF
--- a/app/battacker-web/src/App.tsx
+++ b/app/battacker-web/src/App.tsx
@@ -753,13 +753,11 @@ function TestResultItem({ result }: { result: TestResult }) {
 
   const getStatusIcon = () => {
     if (testResult.blocked) return "✓";
-    if (testResult.detected) return "!";
     return "✗";
   };
 
   const getStatusClass = () => {
     if (testResult.blocked) return "blocked";
-    if (testResult.detected) return "detected";
     return "success";
   };
 

--- a/app/battacker-web/src/hooks/useBattacker.ts
+++ b/app/battacker-web/src/hooks/useBattacker.ts
@@ -64,7 +64,6 @@ export function useBattacker(): UseBattackerReturn {
         console.log("Test results:", testResults.map(r => ({
           name: r.test.name,
           blocked: r.result.blocked,
-          detected: r.result.detected,
           details: r.result.details,
         })));
         const score = calculateDefenseScore(testResults);


### PR DESCRIPTION
## Summary
- AttackResult型からdetectedフィールドが削除されたため、battacker-webのUIコードからも参照を削除
- CIビルドエラー（TS2339: Property 'detected' does not exist on type 'AttackResult'）を修正

## Test plan
- [x] ローカルでbattacker-webのビルドが成功することを確認