### PR TITLE
feat: add OSSF Scorecard Action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,7 +3,7 @@ name: Scorecard supply-chain security
 on:
   branch_protection_rule:
   schedule:
-    - cron: '30 1 * * 6'  # 毎週土曜 01:30 UTC
+    - cron: '30 1 * * 6'
   push:
     branches: [main]
 
@@ -18,26 +18,22 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
+      - uses: ossf/scorecard-action@v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
-      - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- OSSF Scorecard Actionワークフローを追加
- 週次（土曜01:30 UTC）とmainへのpush時にセキュリティスコアを自動評価
- 結果はGitHub Security dashboardとSARIFアーティファクトとして保存

## Test plan
- [ ] canaryマージ後、mainへマージしてワークフロー実行を確認
- [ ] GitHub Security → Code scanningで結果確認
- [ ] https://scorecard.dev/ でバッジ取得可能か確認