### PR TITLE
chore: update ossf/scorecard-action to v2.4.3

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@v2.4.0
+      - uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- ossf/scorecard-action を v2.4.0 から v2.4.3 に更新
- v2.4.3 には Scorecard v5.3.0 が含まれています

## Test plan
- [ ] mainへのマージ後、Scorecardワークフローが正常に実行されることを確認