### PR TITLE
feat: add release attestations for SLSA provenance

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-and-release:
@@ -51,6 +53,19 @@ jobs:
           cd ../firefox-mv2
           zip -r ../../../../pleno-battacker-firefox-canary.zip .
 
+      - name: Generate checksums
+        run: |
+          sha256sum pleno-audit-chrome-canary.zip pleno-audit-firefox-canary.zip pleno-battacker-chrome-canary.zip pleno-battacker-firefox-canary.zip > checksums.txt
+
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
+        with:
+          subject-path: |
+            pleno-audit-chrome-canary.zip
+            pleno-audit-firefox-canary.zip
+            pleno-battacker-chrome-canary.zip
+            pleno-battacker-firefox-canary.zip
+
       - name: Get version
         id: version
         run: |
@@ -69,6 +84,7 @@ jobs:
             pleno-audit-firefox-canary.zip
             pleno-battacker-chrome-canary.zip
             pleno-battacker-firefox-canary.zip
+            checksums.txt
           prerelease: true
           generate_release_notes: true
           make_latest: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-and-release:
@@ -51,6 +53,19 @@ jobs:
           cd ../firefox-mv2
           zip -r ../../../../pleno-battacker-firefox.zip .
 
+      - name: Generate checksums
+        run: |
+          sha256sum pleno-audit-chrome.zip pleno-audit-firefox.zip pleno-battacker-chrome.zip pleno-battacker-firefox.zip > checksums.txt
+
+      - name: Generate attestations
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
+        with:
+          subject-path: |
+            pleno-audit-chrome.zip
+            pleno-audit-firefox.zip
+            pleno-battacker-chrome.zip
+            pleno-battacker-firefox.zip
+
       - name: Get version
         id: version
         run: |
@@ -68,6 +83,7 @@ jobs:
             pleno-audit-firefox.zip
             pleno-battacker-chrome.zip
             pleno-battacker-firefox.zip
+            checksums.txt
           generate_release_notes: true
           make_latest: true
 


### PR DESCRIPTION
## Summary

- Add SLSA build provenance attestations using actions/attest-build-provenance
- Add SHA256 checksums for all release artifacts
- Update permissions to include id-token and attestations

## OSSF Scorecard改善

- Signed-Releases: 0 → 改善予定（provenance付与）
- Branch-Protection: last_push_approval有効化

## Test plan

- [x] ワークフロー構文検証済み
- [ ] 次回リリースでattestation生成確認