### PR TITLE
fix: add declarativeNetRequestFeedback permission for DNR rule matching

### DIFF
--- a/app/audit-extension/wxt.config.ts
+++ b/app/audit-extension/wxt.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     const basePermissions = ["cookies", "storage", "activeTab", "alarms", "webRequest", "management", "notifications"];
 
     // Chrome/Edge MV3 permissions
-    const mv3Permissions = [...basePermissions, "offscreen", "scripting", "declarativeNetRequest", "identity"];
+    const mv3Permissions = [...basePermissions, "offscreen", "scripting", "declarativeNetRequest", "declarativeNetRequestFeedback", "identity"];
 
     // Firefox/Safari MV2 permissions (no offscreen, no scripting)
     const mv2Permissions = basePermissions;


### PR DESCRIPTION
## Summary
- `getMatchedRules()` API requires `declarativeNetRequestFeedback` permission
- Added missing permission to MV3 permissions in `wxt.config.ts`

## Test plan
- [x] Build succeeds with `pnpm dev`
- [x] Generated manifest.json includes the permission
- [x] No DNR errors in extension-monitor logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Chrome/Edge向けの拡張機能の権限設定を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->