### PR TITLE
fix: remove undefined DEFAULT_FORECAST_CONFIG reference

### DIFF
--- a/packages/extension-runtime/src/storage.ts
+++ b/packages/extension-runtime/src/storage.ts
@@ -154,7 +154,6 @@ export async function clearAllStorage(options?: { preserveTheme?: boolean }): Pr
     dataRetentionConfig: DEFAULT_DATA_RETENTION_CONFIG,
     detectionConfig: DEFAULT_DETECTION_CONFIG,
     blockingConfig: DEFAULT_BLOCKING_CONFIG,
-    forecastConfig: DEFAULT_FORECAST_CONFIG,
   };
 
   await api.storage.local.set(defaultSettings);


### PR DESCRIPTION
## Summary
- `clearAllStorage`関数で未定義の`DEFAULT_FORECAST_CONFIG`参照を削除
- ForecastConfigはenterprise featureとして既に削除されていたが、参照が残っていた

## Test plan
- [x] `pnpm test` が全てパス (1617 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ストレージをクリア後、予報設定がリセットされなくなるよう動作を修正しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->