### PR TITLE
fix: dashboard Sidebar props mismatch and DataTable rowKey default

### DIFF
--- a/app/audit-extension/components/DataTable.tsx
+++ b/app/audit-extension/components/DataTable.tsx
@@ -14,7 +14,7 @@ interface DataTableProps<T> {
   columns: Column<T>[];
   pageSize?: number;
   emptyMessage?: string;
-  rowKey: (item: T, index: number) => string;
+  rowKey?: (item: T, index: number) => string;
   rowHighlight?: (item: T) => boolean;
 }
 
@@ -99,7 +99,7 @@ export function DataTable<T>({
   columns,
   pageSize = 25,
   emptyMessage = "データがありません",
-  rowKey,
+  rowKey = (_item: T, index: number) => String(index),
   rowHighlight,
 }: DataTableProps<T>) {
   const { colors, isDark } = useTheme();

--- a/app/web-dashboard/src/App.tsx
+++ b/app/web-dashboard/src/App.tsx
@@ -281,9 +281,9 @@ function DashboardContent() {
     <ThemeContext.Provider value={{ mode: "system", isDark, colors, setMode: () => {} }}>
       <div style={styles.wrapper}>
         <Sidebar
-          items={sidebarItems}
-          activeItem={activeTab}
-          onItemClick={(id) => setActiveTab(id as TabType)}
+          tabs={sidebarItems}
+          activeTab={activeTab}
+          onChange={(id) => setActiveTab(id as TabType)}
         />
         <main style={styles.container}>
           <header style={styles.header}>


### PR DESCRIPTION
## Summary
- Fix Sidebar component props mismatch causing `Cannot read properties of undefined (reading 'map')` error
- Make DataTable rowKey optional with default implementation

## Changes
- `App.tsx`: Fix Sidebar props (items→tabs, activeItem→activeTab, onItemClick→onChange)
- `DataTable.tsx`: Make rowKey optional with default `(_item, index) => String(index)`

## Test plan
- [x] Verified dashboard loads without errors at https://gyu0uirsg9.execute-api.ap-northeast-1.amazonaws.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * テーブルコンポーネントで行キーの指定がオプション化され、未指定時はインデックスに基づく安定したデフォルトキーが自動生成されるようになりました。
  * ナビゲーション（サイドバー）関連コンポーネントのプロパティ名が統一され、扱いやすくなりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->