### PR TITLE
feat: OpenSSF Scorecard改善 - Token-PermissionsとSigned-Releases対応

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -68,10 +68,11 @@ jobs:
             pleno-battacker-firefox-canary.zip
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da54e9c8 # v3.8.1
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: Sign artifacts with Sigstore
         run: |
+          set -e
           for file in pleno-audit-chrome-canary.zip pleno-audit-firefox-canary.zip pleno-battacker-chrome-canary.zip pleno-battacker-firefox-canary.zip checksums.txt; do
             cosign sign-blob "$file" --yes --bundle "${file}.sigstore.json"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,11 @@ jobs:
             pleno-battacker-firefox.zip
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da54e9c8 # v3.8.1
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: Sign artifacts with Sigstore
         run: |
+          set -e
           for file in pleno-audit-chrome.zip pleno-audit-firefox.zip pleno-battacker-chrome.zip pleno-battacker-firefox.zip checksums.txt; do
             cosign sign-blob "$file" --yes --bundle "${file}.sigstore.json"
           done


### PR DESCRIPTION
## Summary

OpenSSF Scorecardのスコア改善を実施しました。

- **Token-Permissions**: Job-level permissionsを導入し、最小権限の原則に準拠
- **Signed-Releases**: Cosign/Sigstoreを使用したアーティファクト署名を実装

## Changes

### 1. Token-Permissions (0 → 10)
- Workflowレベルの`permissions`を`read-all`から`{}`に変更
- Job-levelで必要な権限のみを指定（`contents: write`, `id-token: write`, `attestations: write`）

### 2. Signed-Releases (0 → 8-10)
- Cosignをインストール
- 全アーティファクト（zip、checksums.txt）を署名
- リリースに`.sigstore.json`バンドルを添付

## Test plan

- [ ] canaryリリースで署名ファイルが生成されることを確認
- [ ] リリースアーティファクトが`.sigstore.json`を含むことを確認
- [ ] 次回Scorecardワークフロー実行でスコア改善を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リリースおよびキャナリアリリースのアーティファクトにデジタル署名機能を追加しました。生成された署名ファイル（.sigstore.json）がリリース資産に含まれるようになり、ダウンロードしたファイルの真正性をユーザーが検証できるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->