### PR TITLE
fix: pin ossf/scorecard-action by commit hash

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@v2.4.0
+      - uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- `ossf/scorecard-action`をタグ参照(`v2.4.0`)からコミットSHAハッシュ固定に変更
- Code scanning alert #17 (Pinned-Dependencies) を解消

## Test plan
- [ ] Scorecard workflowが正常に動作すること