### PR TITLE
fix: update CI validate-pr actor check for plenoai app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
             echo "::error::PRs to main must come from canary branch only"
             exit 1
           fi
-          # PRはgithub-actions[bot]のみ許可
-          if [ "$ACTOR" != "github-actions[bot]" ]; then
-            echo "::error::PRs to main can only be created by GitHub Actions"
+          # PRはplenoai[bot]のみ許可
+          if [ "$ACTOR" != "plenoai[bot]" ]; then
+            echo "::error::PRs to main can only be created by plenoai app"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- validate-prジョブのactor検証を `github-actions[bot]` から `plenoai[bot]` に変更
- create-release-prワークフローがGitHub Appトークンを使うようになったため、PRのactorが変わった

## Test plan
- [ ] Release PR (#201) のValidate PRチェックが通ること