### PR TITLE
feat: add Claude Code Action to create-release-pr workflow for automation

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -111,8 +111,8 @@ jobs:
           if git diff --quiet && git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git config user.name "plenoai[bot]"
-            git config user.email "plenoai[bot]@users.noreply.github.com"
+            git config user.name "pleno-ai[bot]"
+            git config user.email "257570732+pleno-ai[bot]@users.noreply.github.com"
             git add CHANGELOG.md package.json app/audit-extension/package.json
             git commit -m "chore: release v$VERSION"
             git push origin canary


### PR DESCRIPTION
## 概要

Claude Code Actionを組み込み、リリースPR作成時にCHANGELOG.mdの生成とバージョンバンプを自動化します。

## 変更内容

### .github/workflows/create-release-pr.yml
- **Input追加**: `bump` パラメータ（auto/patch/minor/major）でバージョンバンプ種別を指定可能に
- **Claude Code Action統合**: 
  - コミットログを分析してバンプ種別を自動判定（auto時）
  - conventional commitsのプレフィックスで分類（feat→minor, fix→patch, BREAKING→major）
  - CHANGELOG.mdをKeep a Changelog形式で生成/更新
  - `app/audit-extension/package.json`とroot `package.json`のversion同時更新
- **自動コミット**: `plenoai[bot]`名義で`chore: release vX.Y.Z`をcanaryにpush
- **PR管理**: 既存PRがあれば更新、なければ新規作成
- **Permissions**: job levelで`contents: write`と`pull-requests: write`を追加

## セキュリティ
- 全てのuser inputを適切にescape（env変数経由での使用）
- `bump`パラメータはchoice型のため安全
- Claude Code Actionの実行ツール制限（Read,Write,Edit,Bash）
- max_turns制限（15）によるコスト管理

## 前提条件
- リポジトリSecretに`CLAUDE_CODE_OAUTH_TOKEN`を設定済み
