### PR TITLE
refactor: cleanup create-release-pr workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -108,17 +108,14 @@ jobs:
           VERSION=$(node -p "require('./app/audit-extension/package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Check if there are changes to commit
           if git diff --quiet && git diff --cached --quiet; then
             echo "No changes to commit"
-            echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git config user.name "plenoai[bot]"
             git config user.email "plenoai[bot]@users.noreply.github.com"
             git add CHANGELOG.md package.json app/audit-extension/package.json
             git commit -m "chore: release v$VERSION"
             git push origin canary
-            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create or update Pull Request
@@ -133,7 +130,7 @@ jobs:
             PR_TITLE="Release v$VERSION"
           fi
 
-          COMMITS=$(git log origin/main..origin/canary --oneline --no-merges | head -20)
+          COMMITS=$(echo "${{ steps.commits.outputs.log }}" | head -20)
           PR_BODY=$(cat <<EOF
           ## Release v$VERSION
 


### PR DESCRIPTION
## Summary
- `changed` output変数の削除（後続ステップで未使用）
- 不要なコメントの削除
- コミットログの重複取得を排除し、`steps.commits.outputs.log`を再利用

## Test plan
- [ ] CI passes