### PR TITLE
fix: improve AI prompt provider display with domain fallback

### DIFF
--- a/app/audit-extension/entrypoints/dashboard/App.tsx
+++ b/app/audit-extension/entrypoints/dashboard/App.tsx
@@ -922,7 +922,13 @@ function DashboardContent() {
             emptyMessage="AIプロンプトは記録されていません"
             columns={[
               { key: "timestamp", header: "日時", width: "160px", render: (p) => new Date(p.timestamp).toLocaleString("ja-JP") },
-              { key: "provider", header: "Provider", width: "100px", render: (p) => <Badge>{p.provider && p.provider !== "unknown" ? p.provider : new URL(p.apiEndpoint).hostname}</Badge> },
+              { key: "provider", header: "Provider", width: "100px", render: (p) => {
+                try {
+                  return <Badge>{p.provider && p.provider !== "unknown" ? p.provider : new URL(p.apiEndpoint).hostname}</Badge>;
+                } catch {
+                  return <Badge>{p.provider || p.apiEndpoint || "unknown"}</Badge>;
+                }
+              } },
               { key: "model", header: "Model", width: "120px", render: (p) => <code style={{ fontSize: "11px" }}>{p.model || "-"}</code> },
               { key: "prompt", header: "プロンプト", render: (p) => truncate(p.prompt.messages?.[0]?.content || p.prompt.text || "", 50) },
               { key: "latency", header: "レスポンス", width: "100px", render: (p) => p.response ? <Badge>{p.response.latencyMs}ms</Badge> : "-" },

--- a/app/audit-extension/entrypoints/popup/components/AIPromptList.tsx
+++ b/app/audit-extension/entrypoints/popup/components/AIPromptList.tsx
@@ -4,6 +4,14 @@ import { Badge } from "../../../components";
 import { usePopupStyles } from "../styles";
 import { useTheme } from "../../../lib/theme";
 
+function safeGetHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url || "unknown";
+  }
+}
+
 interface Props {
   prompts: CapturedAIPrompt[];
 }
@@ -61,7 +69,7 @@ function PromptCard({
     second: "2-digit",
   });
   const preview = getPreview(prompt);
-  const domain = new URL(prompt.apiEndpoint).hostname;
+  const domain = safeGetHostname(prompt.apiEndpoint);
   const displayProvider = prompt.provider && prompt.provider !== "unknown" ? prompt.provider : domain;
 
   return (


### PR DESCRIPTION
## Summary
- プロバイダ名が`unknown`または未設定の場合、APIエンドポイントのドメインをフォールバック表示
- ポップアップのプロンプト一覧から冗長なドメイン表示を除去
- プロバイダBadgeを常に表示するようレイアウトを統一

## Test plan
- [ ] `pnpm dev`で開発環境を起動
- [ ] AIサービス（ChatGPT, Claude等）にアクセス
- [ ] ポップアップでプロバイダ/ドメインのフォールバック表示を確認
- [ ] ダッシュボードでProvider列の表示を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * プロバイダー表示を改善。プロバイダーが不明な場合はAPIエンドポイントのホスト名を試行し、失敗時は既存の表示や"unknown"へフォールバックします。

* **UI改善**
  * プロンプト一覧でプロバイダー、モデル、タイムスタンプを常に表示するよう統一。
  * プレビューはプロンプト本文のみを表示し、不要なドメイン接頭辞を削除しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->