### PR TITLE
remove: action badge feature

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -358,22 +358,6 @@ async function saveStorage(data: Partial<StorageData>) {
   await chrome.storage.local.set(data);
 }
 
-async function updateBadge() {
-  try {
-    const result = await chrome.storage.local.get(["services"]);
-    const services = result.services || {};
-    // Count only problematic detections (NRD or typosquat)
-    const count = Object.values(services).filter(
-      (service: DetectedService) =>
-        service.nrdResult?.isNRD || service.typosquatResult?.isTyposquat
-    ).length;
-    await chrome.action.setBadgeText({ text: count > 0 ? String(count) : "" });
-    await chrome.action.setBadgeBackgroundColor({ color: count > 0 ? "#dc2626" : "#666" });
-  } catch (error) {
-    logger.warn("Failed to update badge:", error);
-  }
-}
-
 function generateEventId(): string {
   return crypto.randomUUID();
 }
@@ -535,7 +519,6 @@ async function addEvent(event: NewEvent): Promise<EventLog> {
 
   // Parquetストアに記録
   await store.addEvents([parquetEvent]);
-  await updateBadge();
   return newEvent;
 }
 
@@ -1163,7 +1146,6 @@ async function updateService(domain: string, update: Partial<DetectedService>) {
     };
 
     await saveStorage({ services: storage.services });
-    await updateBadge();
 
     // Check domain policy for new domains
     if (isNewDomain) {
@@ -1189,7 +1171,6 @@ async function addCookieToService(domain: string, cookie: CookieInfo) {
     }
 
     await saveStorage({ services: storage.services });
-    await updateBadge();
   });
 }
 
@@ -3155,6 +3136,4 @@ export default defineBackground(() => {
       },
     }).catch((err) => logger.debug("Add cookie event failed:", err));
   });
-
-  updateBadge();
 });


### PR DESCRIPTION
## 概要
拡張機能アイコン右下に表示されるAction Badge（NRD/typosquat検出数を示す赤い数字）を削除します。

## 変更内容
- `updateBadge()` 関数の削除
- 4箇所の呼び出し箇所を削除：
  - イベント記録後（`addEvent`関数内）
  - サービス検出後（`updateService`関数内）
  - Cookie検出後（`addCookieToService`関数内）
  - Cookie変更イベントハンドラ内

## テスト
- `pnpm test`: 1751テストすべてパス ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 拡張機能のバッジ更新メカニズムを削除しました。サービス全体におけるNRDおよびタイポスクワット検出の検数表示がリアルタイムで更新されなくなります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->