### PR TITLE
fix: ダッシュボード設定UIのカラースキーマバグ修正

### DIFF
--- a/app/audit-extension/components/SettingsMenu.tsx
+++ b/app/audit-extension/components/SettingsMenu.tsx
@@ -149,6 +149,7 @@ export function SettingsMenu({ onClearData, onExport }: Props) {
         className="hover-bg"
         onClick={() => setIsOpen(!isOpen)}
         style={{
+          background: "transparent",
           border: "none",
           cursor: "pointer",
           padding: "6px",
@@ -325,6 +326,7 @@ export function SettingsMenu({ onClearData, onExport }: Props) {
                 style={{
                   width: "100%",
                   padding: "8px 12px",
+                  background: "transparent",
                   border: "none",
                   cursor: "pointer",
                   display: "flex",
@@ -367,6 +369,7 @@ export function SettingsMenu({ onClearData, onExport }: Props) {
               style={{
                 width: "100%",
                 padding: "8px 12px",
+                background: "transparent",
                 border: "none",
                 cursor: "pointer",
                 display: "flex",

--- a/app/audit-extension/components/ThemeToggle.tsx
+++ b/app/audit-extension/components/ThemeToggle.tsx
@@ -39,6 +39,7 @@ export function ThemeToggle() {
       className="hover-bg"
       style={{
         ...styles.button,
+        background: "transparent",
         color: colors.textSecondary,
       }}
       onClick={() => setMode(nextMode)}


### PR DESCRIPTION
## 問題
設定UI内のボタンで、ダークモード時にライトモードの色が残る（色の混在）が発生していました。
ホバーすると正常な色になるため、通常状態での背景色設定に問題がありました。

## 原因
以下のボタンに `background` CSSプロパティが設定されていませんでした：
- ThemeToggle.tsx: テーマ切り替えボタン
- SettingsMenu.tsx: 設定アイコンボタン、エクスポートボタン、データ削除ボタン

`hover-bg`クラスはホバー時のみ背景色を適用するため、通常状態では透明背景となり、親要素の色が透けて見えていました。

## 修正内容
各ボタンに `background: 'transparent'` を明示的に設定し、通常状態での背景色を統一しました。

## 検証方法
1. `pnpm dev` で開発環境を起動
2. ダッシュボードで設定メニューを開く
3. テーマをダーク→ライト→システムと切り替え
4. 各ボタンの通常状態で色が一貫していることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル
- 設定メニューの複数のボタン（メインの切り替えボタン、エクスポートボタン、データ削除ボタン）およびテーマ切り替えボタンに対して、明示的な透明背景スタイルを適用し、視覚的な一貫性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->