### PR TITLE
refactor: ServiceタブをThreatタブと同じUXパターンに統一

### DIFF
--- a/app/audit-extension/entrypoints/popup/components/ServiceTab.tsx
+++ b/app/audit-extension/entrypoints/popup/components/ServiceTab.tsx
@@ -265,7 +265,8 @@ export function ServiceTab({ services, violations, networkRequests }: ServiceTab
     <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
       <div style={styles.filterBar}>
         <input
-          type="text"
+          type="search"
+          aria-label="サービス検索"
           value={searchQuery}
           onInput={(e) => setSearchQuery((e.target as HTMLInputElement).value)}
           placeholder="検索..."
@@ -349,7 +350,8 @@ export function ServiceTab({ services, violations, networkRequests }: ServiceTab
           </thead>
           <tbody>
             {filtered.slice(0, 100).map((service) => {
-              const isExpanded = expandedIds.has(service.id);
+              const hasConnections = service.connections.length > 0;
+              const isExpanded = hasConnections && expandedIds.has(service.id);
               const isDomain = service.source.type === "domain";
               const displayName = isDomain
                 ? service.source.domain
@@ -361,11 +363,15 @@ export function ServiceTab({ services, violations, networkRequests }: ServiceTab
                 <tr key={service.id} style={popupStyles.tableRow}>
                   <td style={popupStyles.tableCell}>
                     <button
-                      onClick={() => toggleExpand(service.id)}
+                      onClick={() => hasConnections && toggleExpand(service.id)}
+                      disabled={!hasConnections}
+                      aria-label={isExpanded ? "接続を折りたたむ" : "接続を展開する"}
+                      aria-expanded={isExpanded}
                       style={{
                         background: "none",
                         border: "none",
-                        cursor: "pointer",
+                        cursor: hasConnections ? "pointer" : "default",
+                        opacity: hasConnections ? 1 : 0.4,
                         padding: 0,
                         color: colors.textSecondary,
                         fontSize: "10px",


### PR DESCRIPTION
## 概要
popupのServiceタブをThreatタブと同じUXパターンに統一し、ユーザーインターフェースの一貫性を向上させました。

## 変更内容

### UIレイアウト変更
- **アコーディオン形式 → テーブル形式**
  - 5列構成: Icon, Name, Tags, Connections, Time
  - ThreatTabと同じテーブルパターンに統一

### フィルタバー追加
- 検索入力欄（名前/ドメイン検索）
- カテゴリボタン（NRD, Typosquat, AI, login, Extension）
  - カウント > 0 のカテゴリのみ表示
  - トグル形式でフィルタ可能
- ソートセレクト（アクティビティ順/接続数順/名前順）を右端に配置

### テーブル内展開機能
- 行クリックで接続先をテーブル内に子行として表示
- 最大10件表示 + 「他N件」表示
- chevronアイコンで展開状態を視覚化

### フィルタロジック
- テキスト検索: ドメイン名/拡張機能名で検索
- カテゴリフィルタ: 複数カテゴリ同時選択可能
- 表示件数: 最大100件（ThreatTabと同じ）

## デザイン統一
- ThreatTabで採用されているテーブルスタイルを共有
- Badge, Buttonコンポーネントの一貫性を保証
- Vercel風ミニマルデザインシステムを踏襲

## 検証項目
- [ ] フィルタ/検索機能の動作確認
- [ ] テーブル行の展開/折りたたみ動作確認
- [ ] ソート機能の動作確認
- [ ] レスポンシブレイアウト確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * サービスリストを表形式で刷新、列表示（Name／Tags／Connections／Time）に変更
  * テキスト検索を追加
  * カテゴリ別フィルタ（NRD／タイプスクワット／AI／ログイン／拡張）を追加、各カテゴリの件数表示とトグル対応

* **改善**
  * サービスごとに接続一覧を展開表示（個別接続行、長いドメインは省略表示）
  * 上限表示（0–100件スライス）と「+X more」インジケータ、該当なしの空状態を追加

* **スタイル**
  * フィルタバーや入力などUIスタイルを更新

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->