### PR TITLE
refactor: runtime message handlerの責務を再編

### DIFF
--- a/docs/adr/042-runtime-handler-sectioning.md
+++ b/docs/adr/042-runtime-handler-sectioning.md
@@ -1,0 +1,44 @@
+# ADR 042: Runtime Handler定義の機能別セクション化
+
+## ステータス
+
+Accepted
+
+## コンテキスト
+
+- `app/audit-extension/lib/background/runtime-handlers.ts` は runtime message の定義が1箇所に集中している
+- ハンドラー追加時に巨大な配列を横断して編集する必要があり、差分衝突とレビュー負荷が増える
+- 既存の message contract は安定しており、外部仕様は維持したい
+
+## 決定
+
+1. Runtime handler定義を機能別セクション関数へ分割する
+2. `createRuntimeMessageHandlers` は `direct` / `async` の組み立て責務のみに限定する
+3. `execute` / `fallback` のレスポンス契約と message type は既存のまま維持する
+
+### セクション
+
+- Security event handlers
+- CSP handlers
+- Connection and auth handlers
+- AI prompt handlers
+- Domain risk handlers
+- Event store handlers
+- Network and extension handlers
+- Configuration handlers
+
+## 理由
+
+- 可読性: 目的別にまとまるため、特定機能の編集範囲を即座に特定できる
+- 凝集度: 関連メッセージを同一セクションに閉じ込められる
+- 変更容易性: handler追加・削除時の影響範囲を局所化できる
+- 品質維持: 外部契約を維持しつつ内部構造のみ改善できる
+
+## リスクと対応
+
+| リスク | 対応 |
+|--------|------|
+| 同一 message type の重複登録 | セクション統合時に type 一覧を明示し重複を排除する |
+| セクション間の責務境界が曖昧化 | 機能単位の命名規則を固定し、責務に沿って配置する |
+| リファクタリングでレスポンス契約が壊れる | 既存 fallback と message type を変更せず、実機デバッグで応答を確認する |
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@
 | [039](./039-security-event-handler-modularization.md) | Security Event Handlerのモジュール分離 | Accepted |
 | [040](./040-background-csp-ai-service-modularization.md) | BackgroundのCSP/AI監視責務をサービスへ分離する | Accepted |
 | [041](./041-domain-risk-service-modularization.md) | ドメインリスク検知（NRD/Typosquat）をサービスへ分離する | Accepted |
+| [042](./042-runtime-handler-sectioning.md) | Runtime Handler定義の機能別セクション化 | Accepted |


### PR DESCRIPTION
## 概要
`background.ts` と `runtime-handlers.ts` の責務境界を再整理し、挙動を維持したまま runtime message 処理の変更容易性を上げました。

## 変更内容
- `runtime-handlers.ts` の巨大なハンドラー定義を機能別セクション関数へ分割
  - Security events
  - CSP
  - Connection/Auth
  - AI prompt
  - Domain risk
  - Event store
  - Network/Extension
  - Configuration
- `createRuntimeMessageHandlers` は組み立て責務 (`direct` / `async`) のみに簡素化
- `background.ts` で runtime handler 依存オブジェクト生成を `createRuntimeHandlerDependencies()` に抽出
- 未使用 import を削除
- ADR追加: `docs/adr/042-runtime-handler-sectioning.md`

## トレードオフ
- 利点: 可読性・凝集度・変更容易性が向上し、ハンドラー追加時の編集範囲が局所化
- コスト: 関数分割により定義位置のジャンプは増える
- 判断: runtime message 追加頻度と衝突リスクを優先し、分割構造を採用

## 動作確認（実機）
`debug-extension-guide` 手順で確認
1. `pnpm dev` で開発環境起動
2. `DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start status` → Connected
3. `DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start browser open https://example.com` → タブ起動成功
4. `DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start doh config` → 設定取得成功
5. `DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start events count` / `events list --limit 5` → 応答成功
6. `timeout 10 bash -c 'DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start logs' || true` → ログストリーム起動確認
7. `pnpm dev:stop` で停止

## ビルド/静的確認
- `pnpm exec oxlint app/audit-extension/entrypoints/background.ts app/audit-extension/lib/background/runtime-handlers.ts`
- `pnpm -C app/audit-extension build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ランタイムメッセージハンドラーの内部構造を再編成し、保守性を向上

* **Documentation**
  * アーキテクチャ決定ドキュメント (ADR 042) を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->