### PR TITLE
docs: create-adrスキルを追加

### DIFF
--- a/.claude/skills/create-adr/SKILL.md
+++ b/.claude/skills/create-adr/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: create-adr
+description: >
+  ADR（Architecture Decision Record）を作成するスキル。
+  docs/adr/ にストック情報（永続的な意思決定）のみを記録する。
+  Trigger: ADR作成, 設計決定記録, アーキテクチャ決定を記録
+---
+
+# ADR作成
+
+## ルール
+
+- **ストック情報のみ**: リファクタリング手順やプロセスガイドは記録しない
+- フロー情報（段階的手順、一時的な計画）はgit historyやCLAUDE.mdに任せる
+
+## 手順
+
+1. `docs/adr/README.md` を読み、現在の最大番号を取得
+2. 次の番号で `docs/adr/{NNN}-{slug}.md` を作成
+
+```markdown
+# ADR-{NNN}: {タイトル}
+
+## Status
+
+Accepted
+
+## Context
+
+なぜこの決定が必要か。背景と制約。
+
+## Decision
+
+何を決定したか。具体的な方針。
+
+## Consequences
+
+この決定により何が変わるか。トレードオフ。
+```
+
+3. `docs/adr/README.md` のテーブル末尾にエントリを追加
+
+```markdown
+| [{NNN}](./{NNN}-{slug}.md) | {タイトル} | Accepted |
+```
+
+## 判断基準: ADRに記録すべきか
+
+記録する: 技術選定、パッケージ構造、機能設計方針、外部制約への対応
+記録しない: リファクタリングの各ステップ、一時的な計画、開発プロセス


### PR DESCRIPTION
## 概要

ADR作成の手順を簡潔に纏めたスキルを追加しました。
プロジェクトローカルスキル（`.claude/skills/create-adr/`）として保管。

## 内容

- **ルール**: ストック情報（永続的な意思決定）のみを記録
  - 記録しない: リファクタリング手順、プロセスガイド
- **手順**: README.mdから最大番号取得 → ADRファイル作成 → README更新（3ステップ）
- **テンプレート**: Status/Context/Decision/Consequences形式
- **判断基準**: 技術選定、パッケージ構造、機能設計方針、外部制約への対応

## 使用方法

今後ADR作成時に `create-adr` スキルをトリガーしてください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント
* アーキテクチャ決定記録(ADR)の作成と管理に関するドキュメントを追加しました。標準的なADR構造(タイトル、ステータス、コンテキスト、決定、結果)、記録対象となる技術選択やデザイン方針、および作成手順に関するガイドラインを定義しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->