### PR TITLE
fix: improve message-handler and cookie-monitor robustness

### DIFF
--- a/packages/extension-runtime/src/cookie-monitor.ts
+++ b/packages/extension-runtime/src/cookie-monitor.ts
@@ -3,8 +3,15 @@ import { isSessionCookie, type CookieInfo } from "@pleno-audit/detectors";
 export type CookieChangeCallback = (cookie: CookieInfo, removed: boolean) => void;
 
 let listeners: CookieChangeCallback[] = [];
+let isStarted = false;
 
 export function startCookieMonitor() {
+  if (isStarted) {
+    return;
+  }
+
+  isStarted = true;
+
   chrome.cookies.onChanged.addListener((changeInfo) => {
     const { cookie, removed } = changeInfo;
 

--- a/packages/extension-runtime/src/message-handler.test.ts
+++ b/packages/extension-runtime/src/message-handler.test.ts
@@ -154,7 +154,7 @@ describe("createMessageRouter", () => {
       });
     });
 
-    it("returns true for unregistered message types", () => {
+    it("returns false for unregistered message types", () => {
       router.listen();
 
       const listener = mockAddListener.mock.calls[0][0];
@@ -164,7 +164,7 @@ describe("createMessageRouter", () => {
         vi.fn()
       );
 
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
     it("does not call handler for unregistered message types", () => {

--- a/packages/extension-runtime/src/message-handler.ts
+++ b/packages/extension-runtime/src/message-handler.ts
@@ -44,13 +44,13 @@ export function createMessageRouter() {
     chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       const config = handlers.get(message.type);
       if (!config) {
-        return true;
+        return false;
       }
 
       const data = message.data ?? message.payload;
 
-      config
-        .handler(data, sender)
+      Promise.resolve()
+        .then(() => config.handler(data, sender))
         .then(sendResponse)
         .catch((error) => {
           logger.error(`Error handling ${config.logPrefix}:`, error);


### PR DESCRIPTION
## Summary

message-handler.ts と cookie-monitor.ts の堅牢性を改善しました。

## Changes

### message-handler.ts の改善
- **未登録ハンドラー対応**: 未登録メッセージ型に対して `return false` で応答なし に変更
- **例外処理の堅牢化**: 同期例外を `Promise.resolve().then()` でラップして非同期例外に変換し、エラーハンドリングを統一

### cookie-monitor.ts の改善
- **多重登録防止**: `isStarted` フラグを追加して、`startCookieMonitor()` の多重呼び出しを防止
- **リスナー登録ガード**: 既に開始している場合は新規リスナー登録をスキップ

### テスト更新
- message-handler.test.ts: 未登録メッセージの戻り値テストを `true` から `false` に更新

## Test Results
- 全テスト成功: 1779 tests passed

## Files Changed
- packages/extension-runtime/src/message-handler.ts
- packages/extension-runtime/src/message-handler.test.ts
- packages/extension-runtime/src/cookie-monitor.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* クッキーモニターの重複開始を防止し、複数のリスナー登録を回避
* メッセージハンドリングの返却値を修正し、未登録のメッセージタイプに対する適切な処理を実装
* ハンドラー実行の非同期処理を改善し、Promise ベースのフローに統一

<!-- end of auto-generated comment: release notes by coderabbit.ai -->