### PR TITLE
feat: implement Preact ErrorBoundary component

### DIFF
--- a/app/audit-extension/components/ErrorBoundary.tsx
+++ b/app/audit-extension/components/ErrorBoundary.tsx
@@ -1,0 +1,66 @@
+import { Component } from "preact";
+import type { ComponentChild } from "preact";
+import { createLogger } from "@pleno-audit/extension-runtime";
+import { ErrorState, parseErrorMessage } from "./ErrorState";
+
+const logger = createLogger("ErrorBoundary");
+
+interface ErrorBoundaryProps {
+  children: ComponentChild;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: { componentStack: string }) {
+    logger.error("Error caught by boundary:", error);
+    logger.debug("Component stack:", errorInfo.componentStack);
+  }
+
+  handleRetry = () => {
+    this.setState({
+      hasError: false,
+      error: null,
+    });
+  };
+
+  handleHelp = () => {
+    logger.info("User requested help for error");
+    const message =
+      "エラーが発生しました。以下の情報をサポートまでお問い合わせください:\n" +
+      (this.state.error?.message || "不明なエラー");
+    alert(message);
+  };
+
+  render() {
+    if (this.state.hasError && this.state.error) {
+      const { type, technicalDetails } = parseErrorMessage(this.state.error);
+
+      return (
+        <ErrorState
+          type={type}
+          technicalDetails={technicalDetails}
+          onRetry={this.handleRetry}
+          onHelp={this.handleHelp}
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/app/audit-extension/components/index.ts
+++ b/app/audit-extension/components/index.ts
@@ -14,6 +14,7 @@ export { SeverityBadge, type Severity } from "./SeverityBadge";
 export { EmptyState } from "./EmptyState";
 export { LoadingState } from "./LoadingState";
 export { ErrorState, parseErrorMessage, type ErrorType } from "./ErrorState";
+export { ErrorBoundary } from "./ErrorBoundary";
 export { VirtualList, VirtualTable } from "./VirtualList";
 export { StatsGrid } from "./StatsGrid";
 export {

--- a/app/audit-extension/entrypoints/dashboard/App.tsx
+++ b/app/audit-extension/entrypoints/dashboard/App.tsx
@@ -1,6 +1,6 @@
 import { useState } from "preact/hooks";
 import { ThemeContext, useTheme, useThemeState } from "../../lib/theme";
-import { NotificationBanner, Sidebar, useNotifications } from "../../components";
+import { ErrorBoundary, NotificationBanner, Sidebar, useNotifications } from "../../components";
 import { SkeletonDashboard } from "../../components/Skeleton";
 import { DashboardHeader } from "./components/DashboardHeader";
 import { loadingTabs, tabs } from "./constants";
@@ -178,7 +178,9 @@ export function DashboardApp() {
 
   return (
     <ThemeContext.Provider value={themeState}>
-      <DashboardContent />
+      <ErrorBoundary>
+        <DashboardContent />
+      </ErrorBoundary>
     </ThemeContext.Provider>
   );
 }

--- a/app/audit-extension/entrypoints/popup/App.tsx
+++ b/app/audit-extension/entrypoints/popup/App.tsx
@@ -8,7 +8,7 @@ import type { CSPViolation, NetworkRequest } from "@pleno-audit/csp";
 import type { StorageData, DoHRequestRecord } from "@pleno-audit/extension-runtime";
 import { Shield } from "lucide-preact";
 import { ThemeContext, useThemeState, useTheme } from "../../lib/theme";
-import { Badge, Button, PopupSettingsMenu } from "../../components";
+import { Badge, Button, ErrorBoundary, PopupSettingsMenu } from "../../components";
 import {
   ServiceTab,
   EventTab,
@@ -250,7 +250,9 @@ export function App() {
 
   return (
     <ThemeContext.Provider value={themeState}>
-      <PopupContent />
+      <ErrorBoundary>
+        <PopupContent />
+      </ErrorBoundary>
     </ThemeContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- Preact ErrorBoundary コンポーネントを新規作成
- popup/App.tsx と dashboard/App.tsx のルート要素をErrorBoundaryでラップ
- 既存の ErrorState コンポーネントをフォールバックUIとして活用
- createLogger によるエラーログ出力を実装

## Test plan
- [ ] popup でのランタイムエラーがErrorBoundaryにキャッチされることを確認
- [ ] dashboard でのランタイムエラーがErrorBoundaryにキャッチされることを確認
- [ ] フォールバックUIが正しく表示されることを確認
- [ ] 正常時はエラーバウンダリーが透過的であることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * UIにエラーハンドリング機能（ErrorBoundary）を導入しました。
  * 予期しないエラー発生時に画面のクラッシュを防ぎ、エラー情報の表示・再試行・サポート案内が可能です（エラーメッセージは日本語で提示されます）。
  * ダッシュボードとポップアップに適用し、共通コンポーネントとして公開しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->