### PR TITLE
fix: enhance error handling and untracked files detection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Check for untracked files
         run: |
-          UNTRACKED=$(git status --porcelain | grep '^??')
+          UNTRACKED=$(git status --porcelain | grep '^??' || true)
           if [ -n "$UNTRACKED" ]; then
             echo "ERROR: Untracked files detected:"
             echo "$UNTRACKED"
@@ -119,7 +119,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -e
+          set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
           KEEP_COUNT=10
 
@@ -127,6 +127,6 @@ jobs:
             --jq "[.[] | select(.tagName | test(\"^v${VERSION}-[a-f0-9]+$\"))] | sort_by(.createdAt) | reverse | .[${KEEP_COUNT}:] | .[].tagName" \
             | while read -r tag; do
               if [ -n "$tag" ]; then
-                gh release delete "$tag" --yes --cleanup-tag && echo "Deleted: $tag"
+                gh release delete "$tag" --yes --cleanup-tag || echo "Failed to delete: $tag"
               fi
             done


### PR DESCRIPTION
## Summary
- release.yml の未追跡ファイル検出を `git status --porcelain` に変更
- エラーハンドリングの強化

## Test plan
- [ ] release workflow が正常に動作することを確認
- [ ] 未追跡ファイルが正確に検出されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **チューニング/保守**
  * リリース手順に事前チェックを追加し、未追跡ファイルがある場合に処理を中断するようにしました。
  * 各ステップで厳格なエラーハンドリングを導入し、コマンド実行の失敗時に確実に停止するよう改善しました。
  * クリーンアップ処理を強化し、削除失敗時に明確な失敗メッセージを出すようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->