### PR TITLE
refactor: consolidate background message listeners to single handler

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -13,6 +13,7 @@ import {
   migrateToDatabase,
   getSSOManager,
   ensureOffscreenDocument,
+  markOffscreenReady,
   getStorage,
   setStorage,
   clearAIPrompts,
@@ -392,6 +393,7 @@ function createRuntimeHandlerDependencies(): RuntimeHandlerDependencies {
     },
     handleDebugBridgeForward,
     getKnownExtensions,
+    markOffscreenReady,
     handlePageAnalysis: async (payload) =>
       backgroundAnalysis.handlePageAnalysis(payload as PageAnalysis),
     handleCSPViolation: (data, sender) => cspReportingService.handleCSPViolation(data as Omit<CSPViolation, "type">, sender),

--- a/packages/background-services/src/runtime-handlers/direct-handlers.ts
+++ b/packages/background-services/src/runtime-handlers/direct-handlers.ts
@@ -9,7 +9,10 @@ export function createDirectHandlers(
       return false;
     }],
     ["LOCAL_API_REQUEST", () => false],
-    ["OFFSCREEN_READY", () => false],
+    ["OFFSCREEN_READY", () => {
+      deps.markOffscreenReady();
+      return false;
+    }],
     ["DEBUG_BRIDGE_CONNECTED", () => {
       deps.logger.debug("Debug bridge: connected");
       return false;

--- a/packages/background-services/src/runtime-handlers/types.ts
+++ b/packages/background-services/src/runtime-handlers/types.ts
@@ -82,6 +82,7 @@ export interface RuntimeHandlerDependencies {
     data: unknown,
   ) => Promise<{ success: boolean; data?: unknown; error?: string }>;
   getKnownExtensions: () => Record<string, { id: string; name: string; version: string; enabled: boolean; icons?: { size: number; url: string }[] }>;
+  markOffscreenReady: () => void;
 
   handlePageAnalysis: (payload: unknown) => Promise<void>;
   handleCSPViolation: (

--- a/packages/extension-runtime/src/api-client.ts
+++ b/packages/extension-runtime/src/api-client.ts
@@ -29,15 +29,10 @@ let offscreenReady = false;
 let offscreenCreating: Promise<void> | null = null;
 let offscreenReadyResolvers: (() => void)[] = [];
 
-if (typeof chrome !== "undefined" && chrome.runtime?.onMessage) {
-  chrome.runtime.onMessage.addListener((message) => {
-    if (message.type === "OFFSCREEN_READY") {
-      offscreenReady = true;
-      offscreenReadyResolvers.forEach(resolve => resolve());
-      offscreenReadyResolvers = [];
-    }
-    return false;
-  });
+export function markOffscreenReady(): void {
+  offscreenReady = true;
+  offscreenReadyResolvers.forEach(resolve => resolve());
+  offscreenReadyResolvers = [];
 }
 
 async function waitForOffscreenReady(timeout = 15000): Promise<void> {

--- a/packages/extension-runtime/src/index.ts
+++ b/packages/extension-runtime/src/index.ts
@@ -17,6 +17,7 @@ export {
   getApiClient,
   updateApiClientConfig,
   ensureOffscreenDocument,
+  markOffscreenReady,
   type ConnectionMode,
   type ApiClientConfig,
   type QueryOptions,


### PR DESCRIPTION
## Summary
- api-client.tsのグローバル`onMessage`リスナーを削除し、`markOffscreenReady()`関数に置き換え
- backgroundコンテキストのメッセージリスナーを1箇所（background.ts）に統合
- `OFFSCREEN_READY`の状態管理をdirect handler経由で`markOffscreenReady()`を呼び出す方式に変更

## 問題
`api-client.ts`が全メッセージに対して`return false`を返すグローバルリスナーを登録しており、async handlerの`return true`と競合してChrome警告が発生していた:
```
Error: A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received
```

## Test plan
- [x] `pnpm test` 全1871テスト通過
- [x] `pnpm build` ビルド成功
- [ ] 拡張機能でCSPレポート取得時のエラーが解消されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * オフスクリーンリソースの準備完了シグナル機能が追加されました。リソース初期化の処理がより効率的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->