### PR TITLE
fix: prevent stack overflow in parquet-store queryRows with large datasets

### DIFF
--- a/packages/parquet-storage/src/parquet-store.ts
+++ b/packages/parquet-storage/src/parquet-store.ts
@@ -100,7 +100,10 @@ export class ParquetStore {
 
     const rows: Record<string, unknown>[] = [];
     for (const file of files) {
-      rows.push(...this.deserializeParquetData(file.data));
+      const data = this.deserializeParquetData(file.data);
+      for (const row of data) {
+        rows.push(row);
+      }
     }
     return rows;
   }
@@ -303,7 +306,9 @@ export class ParquetStore {
 
     for (const record of records) {
       const data = this.deserializeParquetData(record.data);
-      allData.push(...data);
+      for (const item of data) {
+        allData.push(item);
+      }
     }
 
     return allData;


### PR DESCRIPTION
## Summary
- `parquet-store.ts`の`queryRows()`と`loadDataForType()`で`push(...array)`を使用していたが、大量レコードの場合にJavaScriptのコールスタック制限を超過して`RangeError: Maximum call stack size exceeded`が発生していた
- `push(...spread)`を`for...of`ループに置き換えて修正

## 根本原因
`Array.push(...largeArray)`はスプレッド構文で全要素を引数として渡すため、配列サイズがエンジンのコールスタック制限（通常数万〜数十万引数）を超えるとスタックオーバーフローが発生する。

## Test plan
- [x] `pnpm test` 全1871テスト通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 内部のデータ処理ロジックを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->