### PR TITLE
fix: remove unused variable in battacker-web HistoryTab

### DIFF
--- a/app/battacker-web/src/tabs/HistoryTab.tsx
+++ b/app/battacker-web/src/tabs/HistoryTab.tsx
@@ -16,7 +16,7 @@ export function HistoryTab({ history }: { history: DefenseScore[] }) {
     <div className="test-results">
       <h3>Archived Scan Results</h3>
       <div className="test-list">
-        {sortedHistory.map((entry, index) => (
+        {sortedHistory.map((entry) => (
           <div className="test-item" key={entry.testedAt}>
             <div className={`score-badge grade-${entry.grade}`}>{entry.totalScore}</div>
             <div className="test-info">


### PR DESCRIPTION
## 概要

Deploy Websiteワークフローで`battacker-web`のビルドが失敗していた未使用変数エラーを修正。

## 修正内容

`app/battacker-web/src/tabs/HistoryTab.tsx:19` の `.map((entry, index) =>` から未使用の `index` を削除。

```
TS6133: 'index' is declared but its value is never read.
```

## 背景

PR #284 でCIに`battacker`の`tsc`ビルドを追加したが、`battacker-web`（`tsc -b && vite build`）はDeploy Websiteワークフローでのみ実行され、CIには含まれていなかった。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * コード品質の向上のため、内部実装を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->