### PR TITLE
fix: circuit breaker + eliminate duplicate SERVICE_DETECTION_NETWORK

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_NRD_CONFIG,
   DEFAULT_TYPOSQUAT_CONFIG,
 } from "@pleno-audit/detectors";
-import type { CSPViolation, NetworkRequest } from "@pleno-audit/csp";
+import type { CSPViolation } from "@pleno-audit/csp";
 import { DEFAULT_CSP_CONFIG } from "@pleno-audit/csp";
 import {
   startCookieMonitor,
@@ -401,8 +401,7 @@ function createRuntimeHandlerDependencies(): RuntimeHandlerDependencies {
     handlePageAnalysis: async (payload) =>
       backgroundAnalysis.handlePageAnalysis(payload as PageAnalysis),
     handleCSPViolation: (data, sender) => cspReportingService.handleCSPViolation(data as Omit<CSPViolation, "type">, sender),
-    handleNetworkRequest: (data, sender) => cspReportingService.handleNetworkRequest(data as Omit<NetworkRequest, "type">, sender),
-    handleNetworkInspection: (data, sender) => networkSecurityInspector.handleNetworkInspection(data as NetworkInspectionRequest, sender),
+handleNetworkInspection: (data, sender) => networkSecurityInspector.handleNetworkInspection(data as NetworkInspectionRequest, sender),
     handleDataExfiltration: (data, sender) => securityEventHandlers.handleDataExfiltration(data as DataExfiltrationData, sender),
     handleCredentialTheft: (data, sender) => securityEventHandlers.handleCredentialTheft(data as CredentialTheftData, sender),
     handleSupplyChainRisk: (data, sender) => securityEventHandlers.handleSupplyChainRisk(data as SupplyChainRiskData, sender),

--- a/app/audit-extension/entrypoints/security-bridge.content.ts
+++ b/app/audit-extension/entrypoints/security-bridge.content.ts
@@ -228,7 +228,6 @@ export default defineContentScript({
 
     const securityEvents = [
       "__AI_PROMPT_CAPTURED__",
-      "__SERVICE_DETECTION_NETWORK__",
       "__CREDENTIAL_THEFT_DETECTED__",
       "__SUPPLY_CHAIN_RISK_DETECTED__",
       "__TRACKING_BEACON_DETECTED__",

--- a/packages/background-services/src/runtime-handlers/security-handlers.ts
+++ b/packages/background-services/src/runtime-handlers/security-handlers.ts
@@ -1,4 +1,4 @@
-import type { CSPViolation, NetworkRequest } from "@pleno-audit/csp";
+import type { CSPViolation } from "@pleno-audit/csp";
 import type { AsyncHandlerEntry, RuntimeHandlerDependencies } from "./types";
 
 export function createSecurityEventHandlers(
@@ -16,11 +16,7 @@ export function createSecurityEventHandlers(
       execute: (message, sender) => deps.handleCSPViolation(message.data as Omit<CSPViolation, "type">, sender),
       fallback: () => ({ success: false }),
     }],
-    ["NETWORK_REQUEST", {
-      execute: (message, sender) => deps.handleNetworkRequest(message.data as Omit<NetworkRequest, "type">, sender),
-      fallback: () => ({ success: false }),
-    }],
-    ["NETWORK_INSPECTION_REQUEST", {
+["NETWORK_INSPECTION_REQUEST", {
       execute: (message, sender) => deps.handleNetworkInspection(message.data, sender),
       fallback: () => ({ success: false }),
     }],

--- a/packages/background-services/src/runtime-handlers/types.ts
+++ b/packages/background-services/src/runtime-handlers/types.ts
@@ -89,11 +89,7 @@ export interface RuntimeHandlerDependencies {
     data: Omit<CSPViolation, "type">,
     sender: chrome.runtime.MessageSender,
   ) => Promise<unknown>;
-  handleNetworkRequest: (
-    data: Omit<NetworkRequest, "type">,
-    sender: chrome.runtime.MessageSender,
-  ) => Promise<unknown>;
-  handleNetworkInspection: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+handleNetworkInspection: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleDataExfiltration: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleCredentialTheft: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleSupplyChainRisk: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;


### PR DESCRIPTION
## Summary

- **サーキットブレーカー導入**: `consecutiveSendFailures`カウンタがリセットされずSW復帰後もイベントが永久ドロップされる問題を、明示的な状態マシン(closed/open/half-open)に置換。5秒間隔で自動復帰を試行する
- **SERVICE_DETECTION_NETWORK全廃**: backgroundのwebRequest APIと完全重複していた最大発火源(50-1000+回/ページ)を削除。Main Worldはボディ/DOM属性が必要なイベントのみに限定
- **技術負債解消**: `queue.unshift(...batch)`のspread除去(スタックオーバーフロー防止)、`console.warn`→`createLogger`(ポリシー準拠)

## Detail

### サーキットブレーカー (security-bridge.content.ts)
- `closed`: 正常送信
- `open`: SW不通。イベントはキューに蓄積するがflush試行しない。5秒後にhalf-openへ
- `half-open`: 1バッチだけ試行。成功→closed、失敗→open(バッチはドロップ)

### SERVICE_DETECTION_NETWORK削除 (api-hooks.js + 3ファイル)
- fetch/XHR/WebSocket/Beacon/MutationObserverからの8発火箇所を全削除
- WebSocketフック自体を削除(他用途なし)
- MutationObserverをSupply Chain Riskチェック専用に軽量化
- background側のNETWORK_REQUESTハンドラと配線を削除

### Main Worldに残すイベント (変更なし)
- `NETWORK_INSPECTION_REQUEST` — POSTボディサンプリング(webRequestでは取得不可)
- `AI_PROMPT_CAPTURED` — AIリクエストボディ解析
- `SUPPLY_CHAIN_RISK_DETECTED` — integrity属性チェック(DOM属性アクセスが必要)

## Test plan

- [x] `pnpm test` — 1892 passed
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — 451KB (2KB削減)
- [ ] 手動: 拡張ロード→タブ開く→chrome://serviceworker-internals/でSW停止→5秒後half-open→SW再起動→イベント正常送信再開
- [ ] 手動: ネットワーク監視がbackground webRequestのみで正常動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * サーキットブレーカーパターンを導入し、エラー時の自動復旧メカニズムを追加しました。接続障害時に一時的に通信を遮断し、自動的に復旧を試みるようになります。
  * エラーログをより一貫性のある方法で記録するよう改善しました。

* **Refactor**
  * ネットワーク監視機能を整理し、セキュリティ検査システムを簡潔にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->