### PR TITLE
fix: proactive cookie query on service detection

### DIFF
--- a/packages/extension-runtime/src/cookie-monitor.ts
+++ b/packages/extension-runtime/src/cookie-monitor.ts
@@ -38,3 +38,38 @@ export function onCookieChange(callback: CookieChangeCallback) {
     listeners = listeners.filter((l) => l !== callback);
   };
 }
+
+/**
+ * Proactively query existing cookies for a domain.
+ * Complements the reactive onChanged listener by fetching cookies
+ * that were already set before monitoring started.
+ */
+export async function queryExistingCookies(domain: string): Promise<CookieInfo[]> {
+  const urls = [`https://${domain}`, `http://${domain}`];
+  const seen = new Set<string>();
+  const results: CookieInfo[] = [];
+
+  for (const url of urls) {
+    let cookies: chrome.cookies.Cookie[];
+    try {
+      cookies = await chrome.cookies.getAll({ url });
+    } catch {
+      continue;
+    }
+
+    for (const cookie of cookies) {
+      if (seen.has(cookie.name)) continue;
+      if (!isSessionCookie(cookie.name)) continue;
+
+      seen.add(cookie.name);
+      results.push({
+        name: cookie.name,
+        domain: cookie.domain,
+        detectedAt: Date.now(),
+        isSession: !cookie.expirationDate,
+      });
+    }
+  }
+
+  return results;
+}

--- a/packages/extension-runtime/src/index.ts
+++ b/packages/extension-runtime/src/index.ts
@@ -34,6 +34,7 @@ export { checkMigrationNeeded, migrateToDatabase } from "./migration.js";
 export {
   startCookieMonitor,
   onCookieChange,
+  queryExistingCookies,
   type CookieChangeCallback,
 } from "./cookie-monitor.js";
 


### PR DESCRIPTION
## Summary

- Cookie検出が完全に機能していないバグを修正
- 全サービスで`cookies: []`が返される問題の根本原因に対処

## 問題

`cookie-monitor.ts`は`chrome.cookies.onChanged`のみを監視するリアクティブ方式のため、**サービス検出時に既存のCookieが取得されない**。拡張機能がロードされる前に設定されたCookieは永久に見逃される。

### QA検証結果

| サイト | cookies |
|--------|---------|
| accounts.google.com | `[]` |
| github.com | `[]` |
| slack.com | `[]` |
| chatgpt.com | `[]` |

## 修正内容

1. `queryExistingCookies(domain)` を追加 — `chrome.cookies.getAll()` で既存のセッションCookieをプロアクティブに取得
2. `handlePageAnalysis` で新規ドメイン検出時に自動呼び出し

## Test plan

- [x] 全1894テスト通過
- [x] lint エラーなし
- [ ] デバッガーで実サイト訪問後にcookiesフィールドが空でないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 新規ドメイン検出時に既存クッキーをプロアクティブに自動照会・追跡する機能を実装。HTTPSおよびHTTP両プロトコルに対応し、クッキーの重複排除とセッション属性フィルタリングを実施。検出したクッキー情報を自動で同期保存。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->