### PR TITLE
fix: debuggerのnetwork無効化が反映されない不具合を修正

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -302,7 +302,11 @@ function initializeDebugBridge(): void {
     return;
   }
   void import("@pleno-audit/debug-bridge").then(({ initDebugBridge }) => {
-    initDebugBridge({ getNetworkRequests });
+    initDebugBridge({
+      getNetworkRequests,
+      getNetworkMonitorConfig,
+      setNetworkMonitorConfig,
+    });
   });
 }
 

--- a/packages/debug-bridge/src/handlers.ts
+++ b/packages/debug-bridge/src/handlers.ts
@@ -37,10 +37,11 @@ export function createDebugHandlers(logger: Logger, deps?: DebugBridgeDeps): Deb
     DEBUG_DOH_CONFIG_SET: async (data) =>
       setDoHConfig(data as { action?: string; maxStoredRequests?: number }),
     DEBUG_DOH_REQUESTS: async (data) => getDoHRequests(data as { limit?: number; offset?: number }),
-    DEBUG_NETWORK_CONFIG_GET: async () => getNetworkConfig(),
+    DEBUG_NETWORK_CONFIG_GET: async () => getNetworkConfig(deps),
     DEBUG_NETWORK_CONFIG_SET: async (data) =>
       setNetworkConfig(
-        data as { enabled?: boolean; captureAllRequests?: boolean; excludeOwnExtension?: boolean }
+        data as { enabled?: boolean; captureAllRequests?: boolean; excludeOwnExtension?: boolean },
+        deps
       ),
     DEBUG_NETWORK_REQUESTS_GET: async (data) => {
       const params = data as { limit?: number; initiatorType?: string };

--- a/packages/debug-bridge/src/types.ts
+++ b/packages/debug-bridge/src/types.ts
@@ -1,3 +1,5 @@
+import type { NetworkMonitorConfig } from "@pleno-audit/extension-runtime";
+
 export interface DebugMessage {
   type: string;
   id?: string;
@@ -20,4 +22,8 @@ export interface DebugBridgeDeps {
     limit?: number;
     initiatorType?: string;
   }) => Promise<{ requests: unknown[]; total: number }>;
+  getNetworkMonitorConfig?: () => Promise<NetworkMonitorConfig>;
+  setNetworkMonitorConfig?: (
+    config: NetworkMonitorConfig
+  ) => Promise<{ success: boolean }>;
 }

--- a/packages/extension-runtime/src/storage.test.ts
+++ b/packages/extension-runtime/src/storage.test.ts
@@ -57,6 +57,17 @@ describe("storage", () => {
       expect(result.events).toEqual([]);
       expect(result.cspReports).toEqual([]);
       expect(result.aiPrompts).toEqual([]);
+      expect(result.networkMonitorConfig).toEqual({
+        enabled: true,
+        captureAllRequests: true,
+        excludeOwnExtension: true,
+        excludedDomains: [],
+        excludedExtensions: [],
+      });
+      expect(result.doHMonitorConfig).toEqual({
+        action: "detect",
+        maxStoredRequests: 1000,
+      });
     });
 
     it("returns stored values when available", async () => {
@@ -93,9 +104,14 @@ describe("storage", () => {
           "aiPrompts",
           "aiMonitorConfig",
           "nrdConfig",
+          "networkMonitorConfig",
+          "doHRequests",
+          "doHMonitorConfig",
           "dataRetentionConfig",
           "detectionConfig",
           "blockingConfig",
+          "notificationConfig",
+          "alertCooldown",
         ])
       );
     });
@@ -166,6 +182,20 @@ describe("storage", () => {
       const result = await getStorageKey("aiMonitorConfig");
 
       expect(result).toEqual({ enabled: true });
+    });
+
+    it("returns default config for networkMonitorConfig", async () => {
+      mockStorageGet.mockResolvedValue({});
+
+      const result = await getStorageKey("networkMonitorConfig");
+
+      expect(result).toEqual({
+        enabled: true,
+        captureAllRequests: true,
+        excludeOwnExtension: true,
+        excludedDomains: [],
+        excludedExtensions: [],
+      });
     });
   });
 

--- a/packages/extension-runtime/src/storage.ts
+++ b/packages/extension-runtime/src/storage.ts
@@ -17,11 +17,14 @@ import {
   DEFAULT_DATA_RETENTION_CONFIG,
   DEFAULT_DETECTION_CONFIG,
   DEFAULT_BLOCKING_CONFIG,
+  DEFAULT_NETWORK_MONITOR_CONFIG,
+  DEFAULT_NOTIFICATION_CONFIG,
 } from "./storage-types.js";
 import type { NRDConfig } from "@pleno-audit/detectors";
 import { DEFAULT_NRD_CONFIG } from "@pleno-audit/detectors";
 import { DEFAULT_CSP_CONFIG } from "@pleno-audit/csp";
 import { DEFAULT_AI_MONITOR_CONFIG } from "@pleno-audit/detectors";
+import { DEFAULT_DOH_MONITOR_CONFIG } from "./doh-monitor.js";
 import { getBrowserAPI } from "./browser-adapter.js";
 
 const STORAGE_KEYS = [
@@ -32,9 +35,14 @@ const STORAGE_KEYS = [
   "aiPrompts",
   "aiMonitorConfig",
   "nrdConfig",
+  "networkMonitorConfig",
+  "doHRequests",
+  "doHMonitorConfig",
   "dataRetentionConfig",
   "detectionConfig",
   "blockingConfig",
+  "notificationConfig",
+  "alertCooldown",
 ] as const;
 type StorageKey = (typeof STORAGE_KEYS)[number];
 
@@ -61,12 +69,23 @@ export async function getStorage(): Promise<StorageData> {
     aiMonitorConfig:
       (result.aiMonitorConfig as AIMonitorConfig) || DEFAULT_AI_MONITOR_CONFIG,
     nrdConfig: (result.nrdConfig as NRDConfig) || DEFAULT_NRD_CONFIG,
+    networkMonitorConfig:
+      (result.networkMonitorConfig as StorageData["networkMonitorConfig"]) ||
+      DEFAULT_NETWORK_MONITOR_CONFIG,
+    doHRequests: (result.doHRequests as StorageData["doHRequests"]) || [],
+    doHMonitorConfig:
+      (result.doHMonitorConfig as StorageData["doHMonitorConfig"]) ||
+      DEFAULT_DOH_MONITOR_CONFIG,
     dataRetentionConfig:
       (result.dataRetentionConfig as DataRetentionConfig) || DEFAULT_DATA_RETENTION_CONFIG,
     detectionConfig:
       (result.detectionConfig as DetectionConfig) || DEFAULT_DETECTION_CONFIG,
     blockingConfig:
       (result.blockingConfig as BlockingConfig) || DEFAULT_BLOCKING_CONFIG,
+    notificationConfig:
+      (result.notificationConfig as StorageData["notificationConfig"]) ||
+      DEFAULT_NOTIFICATION_CONFIG,
+    alertCooldown: (result.alertCooldown as StorageData["alertCooldown"]) || {},
   };
 }
 
@@ -88,9 +107,14 @@ export async function getStorageKey<K extends StorageKey>(
     aiPrompts: [],
     aiMonitorConfig: DEFAULT_AI_MONITOR_CONFIG,
     nrdConfig: DEFAULT_NRD_CONFIG,
+    networkMonitorConfig: DEFAULT_NETWORK_MONITOR_CONFIG,
+    doHRequests: [],
+    doHMonitorConfig: DEFAULT_DOH_MONITOR_CONFIG,
     dataRetentionConfig: DEFAULT_DATA_RETENTION_CONFIG,
     detectionConfig: DEFAULT_DETECTION_CONFIG,
     blockingConfig: DEFAULT_BLOCKING_CONFIG,
+    notificationConfig: DEFAULT_NOTIFICATION_CONFIG,
+    alertCooldown: {},
   };
   return (result[key] as StorageData[K]) ?? defaults[key];
 }
@@ -139,9 +163,14 @@ export async function clearAllStorage(options?: { preserveTheme?: boolean }): Pr
     aiPrompts: [],
     aiMonitorConfig: DEFAULT_AI_MONITOR_CONFIG,
     nrdConfig: DEFAULT_NRD_CONFIG,
+    networkMonitorConfig: DEFAULT_NETWORK_MONITOR_CONFIG,
+    doHRequests: [],
+    doHMonitorConfig: DEFAULT_DOH_MONITOR_CONFIG,
     dataRetentionConfig: DEFAULT_DATA_RETENTION_CONFIG,
     detectionConfig: DEFAULT_DETECTION_CONFIG,
     blockingConfig: DEFAULT_BLOCKING_CONFIG,
+    notificationConfig: DEFAULT_NOTIFICATION_CONFIG,
+    alertCooldown: {},
   };
 
   await api.storage.local.set(defaultSettings);


### PR DESCRIPTION
## 概要
Debugger経由で Network Monitor を無効化しても監視が止まらない重大不具合を修正しました。

## 背景（重大度）
`pleno-debug network config --enabled false` 実行後も `network requests` の件数が増加し続け、
「監視停止」というセキュリティ上の重要設定が機能していませんでした。

これにより、利用者は「停止した」と認識していても実際には継続収集される状態になります。

## 再現手順（修正前）
1. `pnpm dev` を起動
2. `DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start network config --enabled false`
3. `DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start browser open https://www.wikipedia.org`
4. `DEBUG_PORT=9223 pnpm --filter @pleno-audit/debugger start network requests -l 1 -p`

期待: total が増えない
実際: total が増える（停止が効かない）

## 根本原因
### Friction Analysis
- Network設定更新の責務が `debug-bridge` 側にも分散し、状態の真実源が二重化していた
- `extension-network-service` がランタイム制御の責務を持つ一方、`debug-bridge` が storage 直書き + runtime message で横断制御していた

### Root Cause Attribution
- 1行ミスではなく、設定反映経路の設計不整合
- 加えて `extension-runtime` の `getStorage()` が `networkMonitorConfig` などのキーを読んでおらず、設定取得時にデフォルトへ巻き戻っていた

## 対応内容
### Consolidation of Meaning
- Network設定の get/set を `debug-bridge` から `background/extension-network-service` へ集約
- `initDebugBridge` に `getNetworkMonitorConfig` / `setNetworkMonitorConfig` を注入して正式経路で反映

### Interface Realignment
- `DebugBridgeDeps` に Network設定APIを追加
- `DEBUG_NETWORK_CONFIG_GET/SET` は deps があれば必ず runtime API を使用するように変更

### Storage層の整合性修正
- `extension-runtime` の storage key 定義とデフォルト値へ以下を追加
  - `networkMonitorConfig`
  - `doHRequests`
  - `doHMonitorConfig`
  - `notificationConfig`
  - `alertCooldown`
- 回帰防止のユニットテストを追加

## 検証
### 自動テスト
- `pnpm vitest run packages/extension-runtime/src/storage.test.ts`

### 実機QA（debugger）
- 無効化状態で遷移しても `network requests total` が増えないことを確認
  - 例: total `435 -> 435`
- 再有効化後は再び増加することを確認
  - 例: total `435 -> 440`

## 影響範囲
- `debug-bridge` の Network設定ハンドリング
- `audit-extension` の debug bridge 初期化依存
- `extension-runtime` の storage 読み書きキー集合


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ネットワークモニター設定の管理機能を追加しました。ネットワークリクエスト監視の有効化、全リクエスト取得、拡張機能除外設定をサポートします。
  * DNS over HTTPSモニター、通知設定、アラートクールダウン機能用のストレージサポートを追加しました。

* **改善**
  * 設定管理システムを強化し、より柔軟な設定の取得・保存が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->