### PR TITLE
refactor(popup): service explorer index

### DIFF
--- a/app/audit-extension/entrypoints/popup/utils/serviceAggregator.ts
+++ b/app/audit-extension/entrypoints/popup/utils/serviceAggregator.ts
@@ -34,31 +34,6 @@ export interface UnifiedService {
 
 export type SortType = "activity" | "connections" | "name";
 
-export function sortServices(
-  services: UnifiedService[],
-  sortType: SortType
-): UnifiedService[] {
-  return [...services].sort((a, b) => {
-    switch (sortType) {
-      case "activity":
-        return b.lastActivity - a.lastActivity;
-      case "connections": {
-        const aCount = a.connections.reduce((sum, c) => sum + c.requestCount, 0);
-        const bCount = b.connections.reduce((sum, c) => sum + c.requestCount, 0);
-        if (bCount !== aCount) return bCount - aCount;
-        return b.lastActivity - a.lastActivity;
-      }
-      case "name": {
-        const aName = a.source.type === "domain" ? a.source.domain : a.source.extensionName;
-        const bName = b.source.type === "domain" ? b.source.domain : b.source.extensionName;
-        return aName.localeCompare(bName);
-      }
-      default:
-        return 0;
-    }
-  });
-}
-
 interface ExtensionStats {
   byExtension: Record<string, { name: string; count: number; domains: string[] }>;
   byDomain: Record<string, { count: number; extensions: string[] }>;

--- a/app/audit-extension/entrypoints/popup/utils/serviceExplorer.ts
+++ b/app/audit-extension/entrypoints/popup/utils/serviceExplorer.ts
@@ -1,0 +1,146 @@
+import type { SortType, UnifiedService } from "./serviceAggregator";
+
+export type FilterCategory = "nrd" | "typosquat" | "ai" | "login" | "extension";
+
+const FILTER_TAGS: FilterCategory[] = [
+  "nrd",
+  "typosquat",
+  "ai",
+  "login",
+  "extension",
+];
+
+interface ServiceIndexEntry {
+  service: UnifiedService;
+  name: string;
+  normalizedName: string;
+  connectionCount: number;
+  tagSet: Set<FilterCategory>;
+}
+
+export interface ServiceIndex {
+  entries: ServiceIndexEntry[];
+  counts: Record<FilterCategory, number>;
+}
+
+export interface ServiceQuery {
+  sortType: SortType;
+  searchQuery: string;
+  activeFilters: Set<FilterCategory>;
+  limit: number;
+}
+
+export interface ServiceQueryResult {
+  services: UnifiedService[];
+  total: number;
+  hasMore: boolean;
+}
+
+function getServiceName(service: UnifiedService): string {
+  return service.source.type === "domain"
+    ? service.source.domain
+    : service.source.extensionName;
+}
+
+function getConnectionCount(service: UnifiedService): number {
+  return service.connections.reduce((sum, conn) => sum + conn.requestCount, 0);
+}
+
+function getTagSet(service: UnifiedService): Set<FilterCategory> {
+  const tagSet = new Set<FilterCategory>();
+  if (service.source.type === "extension") {
+    tagSet.add("extension");
+  }
+  for (const tag of service.tags) {
+    if (tag.type === "nrd") tagSet.add("nrd");
+    if (tag.type === "typosquat") tagSet.add("typosquat");
+    if (tag.type === "ai") tagSet.add("ai");
+    if (tag.type === "login") tagSet.add("login");
+  }
+  return tagSet;
+}
+
+function sortEntries(entries: ServiceIndexEntry[], sortType: SortType): ServiceIndexEntry[] {
+  const result = [...entries];
+  result.sort((a, b) => {
+    switch (sortType) {
+      case "activity":
+        return b.service.lastActivity - a.service.lastActivity;
+      case "connections":
+        if (b.connectionCount !== a.connectionCount) {
+          return b.connectionCount - a.connectionCount;
+        }
+        return b.service.lastActivity - a.service.lastActivity;
+      case "name":
+        return a.name.localeCompare(b.name);
+      default:
+        return 0;
+    }
+  });
+  return result;
+}
+
+export function buildServiceIndex(services: UnifiedService[]): ServiceIndex {
+  const entries = services.map((service) => {
+    const name = getServiceName(service);
+    return {
+      service,
+      name,
+      normalizedName: name.toLowerCase(),
+      connectionCount: getConnectionCount(service),
+      tagSet: getTagSet(service),
+    };
+  });
+
+  const counts = FILTER_TAGS.reduce(
+    (acc, category) => {
+      acc[category] = 0;
+      return acc;
+    },
+    {} as Record<FilterCategory, number>
+  );
+
+  for (const entry of entries) {
+    for (const category of FILTER_TAGS) {
+      if (entry.tagSet.has(category)) {
+        counts[category] += 1;
+      }
+    }
+  }
+
+  return { entries, counts };
+}
+
+export function queryServiceIndex(
+  index: ServiceIndex,
+  query: ServiceQuery
+): ServiceQueryResult {
+  const normalizedQuery = query.searchQuery.trim().toLowerCase();
+  let entries = index.entries;
+
+  if (normalizedQuery) {
+    entries = entries.filter((entry) =>
+      entry.normalizedName.includes(normalizedQuery)
+    );
+  }
+
+  if (query.activeFilters.size > 0) {
+    entries = entries.filter((entry) => {
+      for (const filter of query.activeFilters) {
+        if (entry.tagSet.has(filter)) return true;
+      }
+      return false;
+    });
+  }
+
+  const sorted = sortEntries(entries, query.sortType);
+  const total = sorted.length;
+  const limit = Math.max(query.limit, 0);
+  const limited = limit > 0 ? sorted.slice(0, limit) : sorted;
+
+  return {
+    services: limited.map((entry) => entry.service),
+    total,
+    hasMore: total > limit,
+  };
+}


### PR DESCRIPTION
## Summary
- サービス表示の派生状態をServiceExplorerに集約し、UIの責務を最小化
- 検索/フィルタ/ソートを索引化して責務を明確化
- sortServicesの重複ロジックを削除

## Testing
- 未実施


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * サービス検索・フィルタリング機能の内部処理を最適化しました。カテゴリベースのフィルタリング、検索、並び替え、ページネーション機能がより効率的に動作するようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->