### PR TITLE
fix(popup): イベントタイムスタンプとtyposquatスコア判定の修正

### DIFF
--- a/app/audit-extension/entrypoints/popup/components/EventTab.tsx
+++ b/app/audit-extension/entrypoints/popup/components/EventTab.tsx
@@ -43,18 +43,18 @@ function convertToEvents(
         severity: age !== null && age < 7 ? "critical" : "high",
         title: service.domain,
         domain: service.domain,
-        timestamp: service.lastVisit || Date.now(),
+        timestamp: service.nrdResult.checkedAt,
       });
     }
     if (service.typosquatResult?.isTyposquat) {
-      const score = service.typosquatResult.score || 0;
+      const score = service.typosquatResult.totalScore;
       events.push({
         id: `typosquat-${service.domain}`,
         category: "typosquat",
-        severity: score >= 0.9 ? "critical" : score >= 0.7 ? "high" : "medium",
+        severity: score >= 70 ? "critical" : score >= 40 ? "high" : "medium",
         title: service.domain,
         domain: service.domain,
-        timestamp: service.lastVisit || Date.now(),
+        timestamp: service.typosquatResult.checkedAt,
       });
     }
   }

--- a/app/audit-extension/entrypoints/popup/utils/serviceAggregator.ts
+++ b/app/audit-extension/entrypoints/popup/utils/serviceAggregator.ts
@@ -214,8 +214,7 @@ export async function aggregateServices(
         }))
         .sort((a, b) => b.requestCount - a.requestCount);
 
-      // 拡張機能のlastActivityは、接続があればその存在を示す適度な値、なければ0
-      const lastActivity = connections.length > 0 ? Date.now() - 60000 : 0;
+      const lastActivity = statData?.lastActivityTime ?? 0;
 
       result.push({
         id: `extension:${id}`,

--- a/packages/extension-network-service/src/helpers.ts
+++ b/packages/extension-network-service/src/helpers.ts
@@ -14,7 +14,7 @@ export interface NetworkRequestQueryOptions {
 }
 
 export interface ExtensionStats {
-  byExtension: Record<string, { name: string; count: number; domains: string[] }>;
+  byExtension: Record<string, { name: string; count: number; domains: string[]; lastActivityTime: number }>;
   byDomain: Record<string, { count: number; extensions: string[] }>;
   total: number;
 }
@@ -89,7 +89,7 @@ export function summarizeExtensionStats(
 ): ExtensionStats {
   const byExtension: Record<
     string,
-    { name: string; count: number; domains: Set<string> }
+    { name: string; count: number; domains: Set<string>; lastActivityTime: number }
   > = {};
   const byDomain: Record<string, { count: number; extensions: Set<string> }> = {};
 
@@ -101,10 +101,14 @@ export function summarizeExtensionStats(
         name: request.extensionName || "Unknown",
         count: 0,
         domains: new Set(),
+        lastActivityTime: 0,
       };
     }
     byExtension[request.extensionId].count++;
     byExtension[request.extensionId].domains.add(request.domain);
+    if (request.timestamp > byExtension[request.extensionId].lastActivityTime) {
+      byExtension[request.extensionId].lastActivityTime = request.timestamp;
+    }
 
     if (!byDomain[request.domain]) {
       byDomain[request.domain] = { count: 0, extensions: new Set() };
@@ -119,6 +123,7 @@ export function summarizeExtensionStats(
       name: data.name,
       count: data.count,
       domains: Array.from(data.domains),
+      lastActivityTime: data.lastActivityTime,
     };
   }
 


### PR DESCRIPTION
## Summary

- **EventTab: timestamp修正** — NRD/typosquatイベントの`timestamp`が`service.lastVisit`（存在しないフィールド）または`Date.now()`になっており、常に「現在時刻」が表示されていた。`nrdResult.checkedAt` / `typosquatResult.checkedAt` を使用するよう修正
- **EventTab: typosquat score修正** — `service.typosquatResult.score`は型に存在しないフィールドで常に`undefined→0`。正しくは`totalScore`（0-100スケール）
- **EventTab: severity判定修正** — スコア判定が`>=0.9/0.7`（0-1スケール想定）になっており常に`"medium"`になっていた。`>=70/40`（0-100スケール、`TyposquatConfig`の閾値に準拠）に修正
- **serviceAggregator: 拡張機能のlastActivity修正** — `Date.now()-60000`（毎回ポップアップ開くたびリセット）を`statData.lastActivityTime`（実際の最終通信時刻）に修正
- **helpers: lastActivityTime追加** — `ExtensionStats.byExtension`に`lastActivityTime`フィールドを追加し、`summarizeExtensionStats`でリクエストの最大timestampを集計

## Test plan

- [ ] typosquatが検出されたドメインのイベントタイムスタンプが検出時刻になっていることを確認
- [ ] typosquatのseverityが`totalScore`に応じてcritical/high/mediumに正しく分類されることを確認
- [ ] アクティビティ順ソートで拡張機能が実際の最終通信時刻順に並ぶことを確認
- [ ] `pnpm test` 全テスト通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * NRDおよびタイポスクワット検出イベントのタイムスタンプ精度を改善しました。
  * タイポスクワット重大度の判定ロジックを更新し、より正確な脅威評価を実現しました。
  * 拡張機能のアクティビティ追跡にアクティビティ時刻情報を追加し、データ精度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->