### PR TITLE
feat: introduce error type hierarchy for extension-runtime

### DIFF
--- a/packages/extension-runtime/src/api-client.ts
+++ b/packages/extension-runtime/src/api-client.ts
@@ -2,6 +2,7 @@ import type { CSPViolation, NetworkRequest, CSPReport } from "@pleno-audit/csp";
 import type { LocalApiResponse } from "./offscreen/db-schema.js";
 import { createLogger } from "./logger.js";
 import { getSSOManager } from "./sso-manager.js";
+import { RetryableError, errorMessage } from "./errors.js";
 
 const logger = createLogger("api-client");
 
@@ -121,7 +122,10 @@ function resetOffscreenState(): void {
 }
 
 function isRetryableLocalRequestError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
+  if (error instanceof RetryableError) return true;
+
+  // Fallback: string-based detection for Chrome API errors that we don't control
+  const message = errorMessage(error);
   return (
     message.includes("A listener indicated an asynchronous response by returning true")
     || message.includes("message channel closed before a response was received")

--- a/packages/extension-runtime/src/errors.test.ts
+++ b/packages/extension-runtime/src/errors.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  PlenoAuditError,
+  RetryableError,
+  StorageError,
+  ConfigError,
+  errorMessage,
+} from "./errors.js";
+
+describe("PlenoAuditError", () => {
+  it("has correct name and code", () => {
+    const error = new PlenoAuditError("test", "TEST_CODE");
+
+    expect(error.name).toBe("PlenoAuditError");
+    expect(error.code).toBe("TEST_CODE");
+    expect(error.message).toBe("test");
+  });
+
+  it("preserves cause chain", () => {
+    const cause = new Error("root cause");
+    const error = new PlenoAuditError("wrapper", "WRAP", { cause });
+
+    expect(error.cause).toBe(cause);
+  });
+
+  it("is instanceof Error", () => {
+    const error = new PlenoAuditError("test", "CODE");
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(PlenoAuditError);
+  });
+});
+
+describe("RetryableError", () => {
+  it("is instanceof PlenoAuditError", () => {
+    const error = new RetryableError("transient failure");
+
+    expect(error).toBeInstanceOf(PlenoAuditError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("has code RETRYABLE", () => {
+    const error = new RetryableError("transient failure");
+
+    expect(error.code).toBe("RETRYABLE");
+    expect(error.name).toBe("RetryableError");
+  });
+
+  it("preserves cause", () => {
+    const cause = new Error("channel closed");
+    const error = new RetryableError("retry me", { cause });
+
+    expect(error.cause).toBe(cause);
+  });
+});
+
+describe("StorageError", () => {
+  it("is instanceof PlenoAuditError with correct code", () => {
+    const error = new StorageError("disk full");
+
+    expect(error).toBeInstanceOf(PlenoAuditError);
+    expect(error.code).toBe("STORAGE_ERROR");
+    expect(error.name).toBe("StorageError");
+  });
+});
+
+describe("ConfigError", () => {
+  it("is instanceof PlenoAuditError with correct code", () => {
+    const error = new ConfigError("invalid config");
+
+    expect(error).toBeInstanceOf(PlenoAuditError);
+    expect(error.code).toBe("CONFIG_ERROR");
+    expect(error.name).toBe("ConfigError");
+  });
+});
+
+describe("errorMessage", () => {
+  it("extracts message from Error", () => {
+    expect(errorMessage(new Error("hello"))).toBe("hello");
+  });
+
+  it("extracts message from PlenoAuditError", () => {
+    expect(errorMessage(new RetryableError("retry"))).toBe("retry");
+  });
+
+  it("converts string to string", () => {
+    expect(errorMessage("raw string")).toBe("raw string");
+  });
+
+  it("converts null to 'null'", () => {
+    expect(errorMessage(null)).toBe("null");
+  });
+
+  it("converts undefined to 'undefined'", () => {
+    expect(errorMessage(undefined)).toBe("undefined");
+  });
+
+  it("converts object to string representation", () => {
+    expect(errorMessage({ key: "value" })).toBe("[object Object]");
+  });
+
+  it("converts number to string", () => {
+    expect(errorMessage(42)).toBe("42");
+  });
+});

--- a/packages/extension-runtime/src/errors.ts
+++ b/packages/extension-runtime/src/errors.ts
@@ -1,0 +1,53 @@
+/**
+ * Base error class for all pleno-audit errors.
+ * Provides error code for programmatic handling.
+ */
+export class PlenoAuditError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "PlenoAuditError";
+    this.code = code;
+  }
+}
+
+/**
+ * Indicates the operation can be retried.
+ * Used for transient failures like message channel disconnections.
+ */
+export class RetryableError extends PlenoAuditError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, "RETRYABLE", options);
+    this.name = "RetryableError";
+  }
+}
+
+/**
+ * Storage operation failures (chrome.storage, IndexedDB, ParquetStore).
+ */
+export class StorageError extends PlenoAuditError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, "STORAGE_ERROR", options);
+    this.name = "StorageError";
+  }
+}
+
+/**
+ * Configuration validation/access failures.
+ */
+export class ConfigError extends PlenoAuditError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, "CONFIG_ERROR", options);
+    this.name = "ConfigError";
+  }
+}
+
+/**
+ * Type-safe extraction of error message from unknown error.
+ * Replaces the pattern: error instanceof Error ? error.message : String(error)
+ */
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/packages/extension-runtime/src/index.ts
+++ b/packages/extension-runtime/src/index.ts
@@ -1,3 +1,6 @@
+// Errors
+export { PlenoAuditError, RetryableError, StorageError, ConfigError, errorMessage } from "./errors.js";
+
 // Storage
 export type { StorageData } from "./storage-types.js";
 export {


### PR DESCRIPTION
## Summary
- Add `PlenoAuditError` base class with `code` field for programmatic error handling
- Add `RetryableError`, `StorageError`, `ConfigError` subtypes
- Add `errorMessage()` utility to replace the `error instanceof Error ? error.message : String(error)` pattern (used in 29 files)
- Migrate `isRetryableLocalRequestError` in api-client to check `instanceof RetryableError` first, with string-based fallback for Chrome API errors

## Test plan
- [x] 15 new unit tests for error classes and `errorMessage()` — all pass
- [x] Full test suite (1909 tests) passes
- [x] Lint clean (no new warnings)