### PR TITLE
fix: flush write buffer before reading in ParquetStore

### DIFF
--- a/packages/parquet-storage/src/parquet-store.ts
+++ b/packages/parquet-storage/src/parquet-store.ts
@@ -311,6 +311,7 @@ export class ParquetStore {
     startDate: string,
     endDate: string
   ): Promise<Record<string, unknown>[]> {
+    await this.writeBuffer.flush(type);
     const records = await this.indexedDB.listByDateRange(type, startDate, endDate);
     const allData: Record<string, unknown>[] = [];
 


### PR DESCRIPTION
## Summary
- Purple Team演習でイベントパイプライン断絶バグを発見
- `ParquetStore.loadDataForType()`がwrite bufferをflushせずにIndexedDBを読んでいた
- 5秒のflushタイマー前にGET_EVENTSを呼ぶと0件返却される致命的バグ
- `loadDataForType()`にflushを追加し、全呼び出し元（getEvents, getViolations, getNetworkRequests, getStats）を一括修正

## Test plan
- [ ] `pnpm test` パス確認
- [ ] `pnpm -C app/audit-extension build` ビルド確認
- [ ] battacker-e2e audit-integration テストで検知イベント>0確認