### PR TITLE
feat: add WebSocket monitoring hook for C2 detection

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -65,6 +65,7 @@ import {
   type SuspiciousDownloadData,
   type TrackingBeaconData,
   type XSSDetectedData,
+  type WebSocketConnectionData,
 } from "@pleno-audit/background-services";
 import {
   createExtensionNetworkService,
@@ -460,6 +461,7 @@ handleNetworkInspection: (data, sender) => networkSecurityInspector.handleNetwor
     handleXSSDetected: (data, sender) => securityEventHandlers.handleXSSDetected(data as XSSDetectedData, sender),
     handleDOMScraping: (data, sender) => securityEventHandlers.handleDOMScraping(data as DOMScrapingData, sender),
     handleSuspiciousDownload: (data, sender) => securityEventHandlers.handleSuspiciousDownload(data as SuspiciousDownloadData, sender),
+    handleWebSocketConnection: (data, sender) => securityEventHandlers.handleWebSocketConnection(data as WebSocketConnectionData, sender),
     getCSPReports: cspReportingService.getCSPReports,
     generateCSPPolicy: cspReportingService.generateCSPPolicy,
     generateCSPPolicyByDomain: cspReportingService.generateCSPPolicyByDomain,

--- a/app/audit-extension/entrypoints/security-bridge.content.ts
+++ b/app/audit-extension/entrypoints/security-bridge.content.ts
@@ -263,6 +263,7 @@ export default defineContentScript({
       "__XSS_DETECTED__",
       "__DOM_SCRAPING_DETECTED__",
       "__SUSPICIOUS_DOWNLOAD_DETECTED__",
+      "__WEBSOCKET_CONNECTION_DETECTED__",
     ];
 
     for (const eventType of securityEvents) {

--- a/app/audit-extension/public/hooks/websocket-hooks.js
+++ b/app/audit-extension/public/hooks/websocket-hooks.js
@@ -1,0 +1,42 @@
+;(function() {
+  'use strict'
+  if (window.__PLENO_WEBSOCKET_HOOKS_INITIALIZED__) return
+  window.__PLENO_WEBSOCKET_HOOKS_INITIALIZED__ = true
+
+  const shared = window.__PLENO_HOOKS_SHARED__
+  if (!shared) return
+  const { emitSecurityEvent } = shared
+
+  const OriginalWebSocket = window.WebSocket
+
+  window.WebSocket = function(url, protocols) {
+    const wsUrl = typeof url === 'string' ? url : url.toString()
+
+    try {
+      const parsed = new URL(wsUrl)
+      const isExternal = parsed.hostname !== location.hostname
+
+      if (isExternal) {
+        emitSecurityEvent('__WEBSOCKET_CONNECTION_DETECTED__', {
+          url: wsUrl,
+          hostname: parsed.hostname,
+          protocol: parsed.protocol,
+          isExternal: true,
+          timestamp: Date.now(),
+          pageUrl: location.href
+        })
+      }
+    } catch(e) {}
+
+    if (protocols !== undefined) {
+      return new OriginalWebSocket(url, protocols)
+    }
+    return new OriginalWebSocket(url)
+  }
+
+  window.WebSocket.prototype = OriginalWebSocket.prototype
+  window.WebSocket.CONNECTING = OriginalWebSocket.CONNECTING
+  window.WebSocket.OPEN = OriginalWebSocket.OPEN
+  window.WebSocket.CLOSING = OriginalWebSocket.CLOSING
+  window.WebSocket.CLOSED = OriginalWebSocket.CLOSED
+})()

--- a/app/audit-extension/wxt.config.ts
+++ b/app/audit-extension/wxt.config.ts
@@ -58,10 +58,10 @@ export default defineConfig({
             },
       }),
       web_accessible_resources: isMV2
-        ? ["api-hooks.js", "parquet_wasm_bg.wasm"]
+        ? ["api-hooks.js", "hooks/websocket-hooks.js", "parquet_wasm_bg.wasm"]
         : [
             {
-              resources: ["api-hooks.js", "parquet_wasm_bg.wasm"],
+              resources: ["api-hooks.js", "hooks/websocket-hooks.js", "parquet_wasm_bg.wasm"],
               matches: ["<all_urls>"],
             },
           ],
@@ -70,6 +70,12 @@ export default defineConfig({
         content_scripts: [
           {
             js: ["api-hooks.js"],
+            matches: ["<all_urls>"],
+            run_at: "document_start",
+            world: "MAIN",
+          },
+          {
+            js: ["hooks/websocket-hooks.js"],
             matches: ["<all_urls>"],
             run_at: "document_start",
             world: "MAIN",

--- a/packages/background-services/src/index.ts
+++ b/packages/background-services/src/index.ts
@@ -35,5 +35,6 @@ export {
   type SupplyChainRiskData,
   type SuspiciousDownloadData,
   type TrackingBeaconData,
+  type WebSocketConnectionData,
   type XSSDetectedData,
 } from "./services/security-event-handlers.js";

--- a/packages/background-services/src/runtime-handlers/security-handlers.ts
+++ b/packages/background-services/src/runtime-handlers/security-handlers.ts
@@ -56,5 +56,9 @@ export function createSecurityEventHandlers(
       execute: (message, sender) => deps.handleSuspiciousDownload(message.data, sender),
       fallback: () => ({ success: false }),
     }],
+    ["WEBSOCKET_CONNECTION_DETECTED", {
+      execute: (message, sender) => deps.handleWebSocketConnection(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
   ];
 }

--- a/packages/background-services/src/runtime-handlers/types.ts
+++ b/packages/background-services/src/runtime-handlers/types.ts
@@ -99,6 +99,7 @@ handleNetworkInspection: (data: unknown, sender: chrome.runtime.MessageSender) =
   handleXSSDetected: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleDOMScraping: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleSuspiciousDownload: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleWebSocketConnection: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
 
   getCSPReports: (options?: {
     type?: "csp-violation" | "network-request";

--- a/packages/background-services/src/services/security-event-handlers.ts
+++ b/packages/background-services/src/services/security-event-handlers.ts
@@ -93,6 +93,16 @@ export interface DOMScrapingData {
   callCount: number;
 }
 
+export interface WebSocketConnectionData {
+  source?: string;
+  timestamp?: number;
+  pageUrl?: string;
+  url?: string;
+  hostname?: string;
+  protocol?: string;
+  isExternal?: boolean;
+}
+
 export interface SuspiciousDownloadData {
   source?: string;
   timestamp: string;
@@ -532,6 +542,40 @@ export function createSecurityEventHandlers(
           domain: pageDomain,
           type: data.type,
           filename: sanitizeFilename(data.filename),
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleWebSocketConnection(
+      data: WebSocketConnectionData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl ?? "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "websocket_connection_detected",
+      });
+
+      await deps.addEvent({
+        type: "websocket_connection_detected",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          url: data.url,
+          hostname: data.hostname,
+          isExternal: data.isExternal,
+        },
+      });
+
+      deps.logger.warn({
+        event: "SECURITY_WEBSOCKET_CONNECTION_DETECTED",
+        data: {
+          source: sourceLabel(data.source),
+          domain: pageDomain,
+          hostname: data.hostname,
+          isExternal: data.isExternal,
         },
       });
 


### PR DESCRIPTION
## Summary
- Purple Team演習でWebSocket C2通信が完全に検知不能だったため、WebSocketモニタリングフックを追加
- MAIN worldフック(`websocket-hooks.js`)で`WebSocket`コンストラクタをラップし、外部ホストへの接続を検知
- security-bridge経由でbackgroundサービスにイベントを転送し、`websocket_connection_detected`として監査証跡に記録

## Changes
- `public/hooks/websocket-hooks.js` — MAIN world IIFE hook (WebSocket constructor wrap)
- `wxt.config.ts` — content_scripts + web_accessible_resources登録
- `security-bridge.content.ts` — イベントリスナー追加
- `security-event-handlers.ts` — `WebSocketConnectionData` type + `handleWebSocketConnection` handler
- `security-handlers.ts` / `types.ts` / `background.ts` — ハンドラ配線

## Test plan
- [x] 全1894ユニットテスト pass
- [x] extension build成功 (`hooks/websocket-hooks.js` 1.26KB in output)
- [ ] 手動: WebSocket C2通信を使うページでイベントが記録されることを確認