### PR TITLE
feat: add Worker monitoring hooks for attack detection

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -66,6 +66,9 @@ import {
   type TrackingBeaconData,
   type XSSDetectedData,
   type WebSocketConnectionData,
+  type WorkerCreatedData,
+  type SharedWorkerCreatedData,
+  type ServiceWorkerRegisteredData,
 } from "@pleno-audit/background-services";
 import {
   createExtensionNetworkService,
@@ -462,6 +465,9 @@ handleNetworkInspection: (data, sender) => networkSecurityInspector.handleNetwor
     handleDOMScraping: (data, sender) => securityEventHandlers.handleDOMScraping(data as DOMScrapingData, sender),
     handleSuspiciousDownload: (data, sender) => securityEventHandlers.handleSuspiciousDownload(data as SuspiciousDownloadData, sender),
     handleWebSocketConnection: (data, sender) => securityEventHandlers.handleWebSocketConnection(data as WebSocketConnectionData, sender),
+    handleWorkerCreated: (data, sender) => securityEventHandlers.handleWorkerCreated(data as WorkerCreatedData, sender),
+    handleSharedWorkerCreated: (data, sender) => securityEventHandlers.handleSharedWorkerCreated(data as SharedWorkerCreatedData, sender),
+    handleServiceWorkerRegistered: (data, sender) => securityEventHandlers.handleServiceWorkerRegistered(data as ServiceWorkerRegisteredData, sender),
     getCSPReports: cspReportingService.getCSPReports,
     generateCSPPolicy: cspReportingService.generateCSPPolicy,
     generateCSPPolicyByDomain: cspReportingService.generateCSPPolicyByDomain,

--- a/app/audit-extension/entrypoints/security-bridge.content.ts
+++ b/app/audit-extension/entrypoints/security-bridge.content.ts
@@ -264,6 +264,9 @@ export default defineContentScript({
       "__DOM_SCRAPING_DETECTED__",
       "__SUSPICIOUS_DOWNLOAD_DETECTED__",
       "__WEBSOCKET_CONNECTION_DETECTED__",
+      "__WORKER_CREATED__",
+      "__SHARED_WORKER_CREATED__",
+      "__SERVICE_WORKER_REGISTERED__",
     ];
 
     for (const eventType of securityEvents) {

--- a/app/audit-extension/public/hooks/worker-hooks.js
+++ b/app/audit-extension/public/hooks/worker-hooks.js
@@ -1,0 +1,65 @@
+;(function() {
+  'use strict'
+  if (window.__PLENO_WORKER_HOOKS_INITIALIZED__) return
+  window.__PLENO_WORKER_HOOKS_INITIALIZED__ = true
+
+  const shared = window.__PLENO_HOOKS_SHARED__
+  if (!shared) return
+  const { emitSecurityEvent } = shared
+
+  // Hook Worker constructor
+  const OriginalWorker = window.Worker
+  window.Worker = function(scriptURL, options) {
+    const url = typeof scriptURL === 'string' ? scriptURL : scriptURL.toString()
+    const isBlobUrl = url.startsWith('blob:')
+
+    emitSecurityEvent('__WORKER_CREATED__', {
+      url: isBlobUrl ? 'blob:' : url,
+      isBlobUrl: isBlobUrl,
+      type: options?.type || 'classic',
+      timestamp: Date.now(),
+      pageUrl: location.href
+    })
+
+    return new OriginalWorker(scriptURL, options)
+  }
+  window.Worker.prototype = OriginalWorker.prototype
+
+  // Hook SharedWorker constructor
+  if (window.SharedWorker) {
+    const OriginalSharedWorker = window.SharedWorker
+    window.SharedWorker = function(scriptURL, options) {
+      const url = typeof scriptURL === 'string' ? scriptURL : scriptURL.toString()
+      const isBlobUrl = url.startsWith('blob:')
+
+      emitSecurityEvent('__SHARED_WORKER_CREATED__', {
+        url: isBlobUrl ? 'blob:' : url,
+        isBlobUrl: isBlobUrl,
+        name: typeof options === 'string' ? options : options?.name,
+        timestamp: Date.now(),
+        pageUrl: location.href
+      })
+
+      return new OriginalSharedWorker(scriptURL, options)
+    }
+    window.SharedWorker.prototype = OriginalSharedWorker.prototype
+  }
+
+  // Hook ServiceWorker registration
+  if (navigator.serviceWorker) {
+    const originalRegister = navigator.serviceWorker.register.bind(navigator.serviceWorker)
+    navigator.serviceWorker.register = function(scriptURL, options) {
+      const url = typeof scriptURL === 'string' ? scriptURL : scriptURL.toString()
+
+      emitSecurityEvent('__SERVICE_WORKER_REGISTERED__', {
+        url: url,
+        scope: options?.scope,
+        type: options?.type || 'classic',
+        timestamp: Date.now(),
+        pageUrl: location.href
+      })
+
+      return originalRegister(scriptURL, options)
+    }
+  }
+})()

--- a/app/audit-extension/wxt.config.ts
+++ b/app/audit-extension/wxt.config.ts
@@ -58,10 +58,10 @@ export default defineConfig({
             },
       }),
       web_accessible_resources: isMV2
-        ? ["api-hooks.js", "hooks/websocket-hooks.js", "parquet_wasm_bg.wasm"]
+        ? ["api-hooks.js", "hooks/websocket-hooks.js", "hooks/worker-hooks.js", "parquet_wasm_bg.wasm"]
         : [
             {
-              resources: ["api-hooks.js", "hooks/websocket-hooks.js", "parquet_wasm_bg.wasm"],
+              resources: ["api-hooks.js", "hooks/websocket-hooks.js", "hooks/worker-hooks.js", "parquet_wasm_bg.wasm"],
               matches: ["<all_urls>"],
             },
           ],
@@ -76,6 +76,12 @@ export default defineConfig({
           },
           {
             js: ["hooks/websocket-hooks.js"],
+            matches: ["<all_urls>"],
+            run_at: "document_start",
+            world: "MAIN",
+          },
+          {
+            js: ["hooks/worker-hooks.js"],
             matches: ["<all_urls>"],
             run_at: "document_start",
             world: "MAIN",

--- a/packages/background-services/src/index.ts
+++ b/packages/background-services/src/index.ts
@@ -37,4 +37,7 @@ export {
   type TrackingBeaconData,
   type WebSocketConnectionData,
   type XSSDetectedData,
+  type WorkerCreatedData,
+  type SharedWorkerCreatedData,
+  type ServiceWorkerRegisteredData,
 } from "./services/security-event-handlers.js";

--- a/packages/background-services/src/runtime-handlers/security-handlers.ts
+++ b/packages/background-services/src/runtime-handlers/security-handlers.ts
@@ -60,5 +60,17 @@ export function createSecurityEventHandlers(
       execute: (message, sender) => deps.handleWebSocketConnection(message.data, sender),
       fallback: () => ({ success: false }),
     }],
+    ["WORKER_CREATED", {
+      execute: (message, sender) => deps.handleWorkerCreated(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
+    ["SHARED_WORKER_CREATED", {
+      execute: (message, sender) => deps.handleSharedWorkerCreated(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
+    ["SERVICE_WORKER_REGISTERED", {
+      execute: (message, sender) => deps.handleServiceWorkerRegistered(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
   ];
 }

--- a/packages/background-services/src/runtime-handlers/types.ts
+++ b/packages/background-services/src/runtime-handlers/types.ts
@@ -100,6 +100,9 @@ handleNetworkInspection: (data: unknown, sender: chrome.runtime.MessageSender) =
   handleDOMScraping: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleSuspiciousDownload: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleWebSocketConnection: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleWorkerCreated: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleSharedWorkerCreated: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleServiceWorkerRegistered: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
 
   getCSPReports: (options?: {
     type?: "csp-violation" | "network-request";

--- a/packages/background-services/src/services/security-event-handlers.ts
+++ b/packages/background-services/src/services/security-event-handlers.ts
@@ -115,6 +115,33 @@ export interface SuspiciousDownloadData {
   mimeType: string;
 }
 
+export interface WorkerCreatedData {
+  source?: string;
+  url?: string;
+  isBlobUrl?: boolean;
+  type?: string;
+  timestamp?: number;
+  pageUrl?: string;
+}
+
+export interface SharedWorkerCreatedData {
+  source?: string;
+  url?: string;
+  isBlobUrl?: boolean;
+  name?: string;
+  timestamp?: number;
+  pageUrl?: string;
+}
+
+export interface ServiceWorkerRegisteredData {
+  source?: string;
+  url?: string;
+  scope?: string;
+  type?: string;
+  timestamp?: number;
+  pageUrl?: string;
+}
+
 interface SecurityEventHandlerDependencies {
   addEvent: (event: AuditEventInput) => Promise<unknown>;
   getAlertManager: () => AlertManager;
@@ -576,6 +603,111 @@ export function createSecurityEventHandlers(
           domain: pageDomain,
           hostname: data.hostname,
           isExternal: data.isExternal,
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleWorkerCreated(
+      data: WorkerCreatedData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl || "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "worker_created",
+      });
+
+      await deps.addEvent({
+        type: "worker_created",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          url: data.url,
+          isBlobUrl: data.isBlobUrl,
+          type: data.type,
+          pageUrl: data.pageUrl,
+        },
+      });
+
+      deps.logger.debug({
+        event: "SECURITY_WORKER_CREATED",
+        data: {
+          source: sourceLabel(data.source),
+          domain: pageDomain,
+          url: data.url,
+          isBlobUrl: data.isBlobUrl,
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleSharedWorkerCreated(
+      data: SharedWorkerCreatedData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl || "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "shared_worker_created",
+      });
+
+      await deps.addEvent({
+        type: "shared_worker_created",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          url: data.url,
+          isBlobUrl: data.isBlobUrl,
+          name: data.name,
+          pageUrl: data.pageUrl,
+        },
+      });
+
+      deps.logger.debug({
+        event: "SECURITY_SHARED_WORKER_CREATED",
+        data: {
+          source: sourceLabel(data.source),
+          domain: pageDomain,
+          url: data.url,
+          isBlobUrl: data.isBlobUrl,
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleServiceWorkerRegistered(
+      data: ServiceWorkerRegisteredData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl || "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "service_worker_registered",
+      });
+
+      await deps.addEvent({
+        type: "service_worker_registered",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          url: data.url,
+          scope: data.scope,
+          type: data.type,
+          pageUrl: data.pageUrl,
+        },
+      });
+
+      deps.logger.debug({
+        event: "SECURITY_SERVICE_WORKER_REGISTERED",
+        data: {
+          source: sourceLabel(data.source),
+          domain: pageDomain,
+          url: data.url,
+          scope: data.scope,
         },
       });
 


### PR DESCRIPTION
## Summary
- Add MAIN world hooks for `Worker`, `SharedWorker`, and `ServiceWorker.register()` to detect covert worker-based attacks (cryptojacking, data exfiltration via blob workers)
- Wire new `__WORKER_CREATED__`, `__SHARED_WORKER_CREATED__`, `__SERVICE_WORKER_REGISTERED__` events through security-bridge, runtime handlers, and event persistence
- Purple Team演習でBlue Team検知カバレッジのギャップを埋める

## Test plan
- [x] All 1894 unit tests pass (`pnpm test`)
- [x] Extension builds successfully (`pnpm -C app/audit-extension build`)
- [ ] Manual: Load extension, visit page that creates a Worker → verify `worker_created` event stored
- [ ] Manual: Visit page that registers a ServiceWorker → verify `service_worker_registered` event stored
- [ ] Manual: Blob URL worker creation is detected with `isBlobUrl: true`