### PR TITLE
feat: add injection and privacy detection hooks

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -69,6 +69,10 @@ import {
   type WorkerCreatedData,
   type SharedWorkerCreatedData,
   type ServiceWorkerRegisteredData,
+  type DynamicCodeExecutionData,
+  type FullscreenPhishingData,
+  type ClipboardReadData,
+  type GeolocationAccessedData,
 } from "@pleno-audit/background-services";
 import {
   createExtensionNetworkService,
@@ -468,6 +472,10 @@ handleNetworkInspection: (data, sender) => networkSecurityInspector.handleNetwor
     handleWorkerCreated: (data, sender) => securityEventHandlers.handleWorkerCreated(data as WorkerCreatedData, sender),
     handleSharedWorkerCreated: (data, sender) => securityEventHandlers.handleSharedWorkerCreated(data as SharedWorkerCreatedData, sender),
     handleServiceWorkerRegistered: (data, sender) => securityEventHandlers.handleServiceWorkerRegistered(data as ServiceWorkerRegisteredData, sender),
+    handleDynamicCodeExecution: (data, sender) => securityEventHandlers.handleDynamicCodeExecution(data as DynamicCodeExecutionData, sender),
+    handleFullscreenPhishing: (data, sender) => securityEventHandlers.handleFullscreenPhishing(data as FullscreenPhishingData, sender),
+    handleClipboardRead: (data, sender) => securityEventHandlers.handleClipboardRead(data as ClipboardReadData, sender),
+    handleGeolocationAccessed: (data, sender) => securityEventHandlers.handleGeolocationAccessed(data as GeolocationAccessedData, sender),
     getCSPReports: cspReportingService.getCSPReports,
     generateCSPPolicy: cspReportingService.generateCSPPolicy,
     generateCSPPolicyByDomain: cspReportingService.generateCSPPolicyByDomain,

--- a/app/audit-extension/entrypoints/security-bridge.content.ts
+++ b/app/audit-extension/entrypoints/security-bridge.content.ts
@@ -99,6 +99,8 @@ export default defineContentScript({
       "DOM_SCRAPING_DETECTED",
       "TRACKING_BEACON_DETECTED",
       "NETWORK_INSPECTION_REQUEST",
+      "DYNAMIC_CODE_EXECUTION_DETECTED",
+      "GEOLOCATION_ACCESSED",
     ]);
     const HIGH_PRIORITY_TYPES = new Set([
       "AI_PROMPT_CAPTURED",
@@ -267,6 +269,10 @@ export default defineContentScript({
       "__WORKER_CREATED__",
       "__SHARED_WORKER_CREATED__",
       "__SERVICE_WORKER_REGISTERED__",
+      "__DYNAMIC_CODE_EXECUTION_DETECTED__",
+      "__FULLSCREEN_PHISHING_DETECTED__",
+      "__CLIPBOARD_READ_DETECTED__",
+      "__GEOLOCATION_ACCESSED__",
     ];
 
     for (const eventType of securityEvents) {

--- a/app/audit-extension/public/hooks/injection-hooks.js
+++ b/app/audit-extension/public/hooks/injection-hooks.js
@@ -1,0 +1,106 @@
+;(function() {
+  'use strict'
+  if (window.__PLENO_INJECTION_HOOKS_INITIALIZED__) return
+  window.__PLENO_INJECTION_HOOKS_INITIALIZED__ = true
+
+  var shared = window.__PLENO_HOOKS_SHARED__
+  if (!shared) return
+  var emitSecurityEvent = shared.emitSecurityEvent
+
+  // Hook eval()
+  var originalEval = window.eval
+  window.eval = function(code) {
+    emitSecurityEvent('__DYNAMIC_CODE_EXECUTION_DETECTED__', {
+      method: 'eval',
+      codeLength: typeof code === 'string' ? code.length : 0,
+      codeSample: typeof code === 'string' ? code.substring(0, 200) : '',
+      timestamp: Date.now(),
+      pageUrl: location.href
+    })
+    return originalEval.call(this, code)
+  }
+
+  // Hook Function constructor
+  var OriginalFunction = window.Function
+  window.Function = function() {
+    var args = Array.prototype.slice.call(arguments)
+    var body = args.length > 0 ? args[args.length - 1] : ''
+
+    emitSecurityEvent('__DYNAMIC_CODE_EXECUTION_DETECTED__', {
+      method: 'Function',
+      codeLength: typeof body === 'string' ? body.length : 0,
+      codeSample: typeof body === 'string' ? body.substring(0, 200) : '',
+      argCount: args.length,
+      timestamp: Date.now(),
+      pageUrl: location.href
+    })
+
+    return OriginalFunction.apply(this, arguments)
+  }
+  window.Function.prototype = OriginalFunction.prototype
+
+  // Hook requestFullscreen
+  var originalRequestFullscreen = Element.prototype.requestFullscreen
+  if (originalRequestFullscreen) {
+    Element.prototype.requestFullscreen = function(options) {
+      emitSecurityEvent('__FULLSCREEN_PHISHING_DETECTED__', {
+        element: this.tagName,
+        elementId: this.id || null,
+        className: this.className || null,
+        timestamp: Date.now(),
+        pageUrl: location.href
+      })
+      return originalRequestFullscreen.call(this, options)
+    }
+  }
+  // Webkit prefix
+  if (Element.prototype.webkitRequestFullscreen) {
+    var originalWebkitFullscreen = Element.prototype.webkitRequestFullscreen
+    Element.prototype.webkitRequestFullscreen = function() {
+      emitSecurityEvent('__FULLSCREEN_PHISHING_DETECTED__', {
+        element: this.tagName,
+        elementId: this.id || null,
+        timestamp: Date.now(),
+        pageUrl: location.href
+      })
+      return originalWebkitFullscreen.apply(this, arguments)
+    }
+  }
+
+  // Hook clipboard.readText
+  if (navigator.clipboard && navigator.clipboard.readText) {
+    var originalReadText = navigator.clipboard.readText.bind(navigator.clipboard)
+    navigator.clipboard.readText = function() {
+      emitSecurityEvent('__CLIPBOARD_READ_DETECTED__', {
+        timestamp: Date.now(),
+        pageUrl: location.href
+      })
+      return originalReadText()
+    }
+  }
+
+  // Hook geolocation
+  if (navigator.geolocation) {
+    var originalGetCurrentPosition = navigator.geolocation.getCurrentPosition.bind(navigator.geolocation)
+    navigator.geolocation.getCurrentPosition = function(success, error, options) {
+      emitSecurityEvent('__GEOLOCATION_ACCESSED__', {
+        method: 'getCurrentPosition',
+        highAccuracy: options?.enableHighAccuracy || false,
+        timestamp: Date.now(),
+        pageUrl: location.href
+      })
+      return originalGetCurrentPosition(success, error, options)
+    }
+
+    var originalWatchPosition = navigator.geolocation.watchPosition.bind(navigator.geolocation)
+    navigator.geolocation.watchPosition = function(success, error, options) {
+      emitSecurityEvent('__GEOLOCATION_ACCESSED__', {
+        method: 'watchPosition',
+        highAccuracy: options?.enableHighAccuracy || false,
+        timestamp: Date.now(),
+        pageUrl: location.href
+      })
+      return originalWatchPosition(success, error, options)
+    }
+  }
+})()

--- a/app/audit-extension/wxt.config.ts
+++ b/app/audit-extension/wxt.config.ts
@@ -58,10 +58,10 @@ export default defineConfig({
             },
       }),
       web_accessible_resources: isMV2
-        ? ["api-hooks.js", "hooks/websocket-hooks.js", "hooks/worker-hooks.js", "parquet_wasm_bg.wasm"]
+        ? ["api-hooks.js", "hooks/websocket-hooks.js", "hooks/worker-hooks.js", "hooks/injection-hooks.js", "parquet_wasm_bg.wasm"]
         : [
             {
-              resources: ["api-hooks.js", "hooks/websocket-hooks.js", "hooks/worker-hooks.js", "parquet_wasm_bg.wasm"],
+              resources: ["api-hooks.js", "hooks/websocket-hooks.js", "hooks/worker-hooks.js", "hooks/injection-hooks.js", "parquet_wasm_bg.wasm"],
               matches: ["<all_urls>"],
             },
           ],
@@ -82,6 +82,12 @@ export default defineConfig({
           },
           {
             js: ["hooks/worker-hooks.js"],
+            matches: ["<all_urls>"],
+            run_at: "document_start",
+            world: "MAIN",
+          },
+          {
+            js: ["hooks/injection-hooks.js"],
             matches: ["<all_urls>"],
             run_at: "document_start",
             world: "MAIN",

--- a/packages/background-services/src/index.ts
+++ b/packages/background-services/src/index.ts
@@ -40,4 +40,8 @@ export {
   type WorkerCreatedData,
   type SharedWorkerCreatedData,
   type ServiceWorkerRegisteredData,
+  type DynamicCodeExecutionData,
+  type FullscreenPhishingData,
+  type ClipboardReadData,
+  type GeolocationAccessedData,
 } from "./services/security-event-handlers.js";

--- a/packages/background-services/src/runtime-handlers/security-handlers.ts
+++ b/packages/background-services/src/runtime-handlers/security-handlers.ts
@@ -72,5 +72,21 @@ export function createSecurityEventHandlers(
       execute: (message, sender) => deps.handleServiceWorkerRegistered(message.data, sender),
       fallback: () => ({ success: false }),
     }],
+    ["DYNAMIC_CODE_EXECUTION_DETECTED", {
+      execute: (message, sender) => deps.handleDynamicCodeExecution(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
+    ["FULLSCREEN_PHISHING_DETECTED", {
+      execute: (message, sender) => deps.handleFullscreenPhishing(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
+    ["CLIPBOARD_READ_DETECTED", {
+      execute: (message, sender) => deps.handleClipboardRead(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
+    ["GEOLOCATION_ACCESSED", {
+      execute: (message, sender) => deps.handleGeolocationAccessed(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
   ];
 }

--- a/packages/background-services/src/runtime-handlers/types.ts
+++ b/packages/background-services/src/runtime-handlers/types.ts
@@ -103,6 +103,10 @@ handleNetworkInspection: (data: unknown, sender: chrome.runtime.MessageSender) =
   handleWorkerCreated: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleSharedWorkerCreated: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleServiceWorkerRegistered: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleDynamicCodeExecution: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleFullscreenPhishing: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleClipboardRead: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleGeolocationAccessed: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
 
   getCSPReports: (options?: {
     type?: "csp-violation" | "network-request";

--- a/packages/background-services/src/services/security-event-handlers.ts
+++ b/packages/background-services/src/services/security-event-handlers.ts
@@ -142,6 +142,35 @@ export interface ServiceWorkerRegisteredData {
   pageUrl?: string;
 }
 
+export interface DynamicCodeExecutionData {
+  method?: string;
+  codeLength?: number;
+  codeSample?: string;
+  argCount?: number;
+  timestamp?: number;
+  pageUrl?: string;
+}
+
+export interface FullscreenPhishingData {
+  element?: string;
+  elementId?: string | null;
+  className?: string | null;
+  timestamp?: number;
+  pageUrl?: string;
+}
+
+export interface ClipboardReadData {
+  timestamp?: number;
+  pageUrl?: string;
+}
+
+export interface GeolocationAccessedData {
+  method?: string;
+  highAccuracy?: boolean;
+  timestamp?: number;
+  pageUrl?: string;
+}
+
 interface SecurityEventHandlerDependencies {
   addEvent: (event: AuditEventInput) => Promise<unknown>;
   getAlertManager: () => AlertManager;
@@ -708,6 +737,136 @@ export function createSecurityEventHandlers(
           domain: pageDomain,
           url: data.url,
           scope: data.scope,
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleDynamicCodeExecution(
+      data: DynamicCodeExecutionData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl || "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "dynamic_code_execution_detected",
+      });
+
+      await deps.addEvent({
+        type: "dynamic_code_execution_detected",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          method: data.method,
+          codeLength: data.codeLength,
+          codeSample: data.codeSample,
+          argCount: data.argCount,
+          pageUrl: data.pageUrl,
+        },
+      });
+
+      deps.logger.warn({
+        event: "SECURITY_DYNAMIC_CODE_EXECUTION_DETECTED",
+        data: {
+          domain: pageDomain,
+          method: data.method,
+          codeLength: data.codeLength,
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleFullscreenPhishing(
+      data: FullscreenPhishingData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl || "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "fullscreen_phishing_detected",
+      });
+
+      await deps.addEvent({
+        type: "fullscreen_phishing_detected",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          element: data.element,
+          elementId: data.elementId,
+          className: data.className,
+          pageUrl: data.pageUrl,
+        },
+      });
+
+      deps.logger.warn({
+        event: "SECURITY_FULLSCREEN_PHISHING_DETECTED",
+        data: {
+          domain: pageDomain,
+          element: data.element,
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleClipboardRead(
+      data: ClipboardReadData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl || "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "clipboard_read_detected",
+      });
+
+      await deps.addEvent({
+        type: "clipboard_read_detected",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          pageUrl: data.pageUrl,
+        },
+      });
+
+      deps.logger.warn({
+        event: "SECURITY_CLIPBOARD_READ_DETECTED",
+        data: {
+          domain: pageDomain,
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleGeolocationAccessed(
+      data: GeolocationAccessedData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl || "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "geolocation_accessed",
+      });
+
+      await deps.addEvent({
+        type: "geolocation_accessed",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          method: data.method,
+          highAccuracy: data.highAccuracy,
+          pageUrl: data.pageUrl,
+        },
+      });
+
+      deps.logger.warn({
+        event: "SECURITY_GEOLOCATION_ACCESSED",
+        data: {
+          domain: pageDomain,
+          method: data.method,
+          highAccuracy: data.highAccuracy,
         },
       });
 


### PR DESCRIPTION
## Summary
- Add MAIN world hooks (`injection-hooks.js`) detecting eval/Function constructor invocation, requestFullscreen phishing, clipboard.readText, and geolocation API access
- Wire 4 new security event types through the full pipeline: hooks -> security-bridge -> runtime-handlers -> security-event-handlers -> background
- Classify `DYNAMIC_CODE_EXECUTION_DETECTED` and `GEOLOCATION_ACCESSED` as low-priority to throttle high-frequency callers

## Test plan
- [x] All 1894 unit tests pass (`pnpm test`)
- [x] Extension builds successfully (`pnpm -C app/audit-extension build`)
- [ ] Verify eval() detection fires on pages using dynamic code execution
- [ ] Verify fullscreen phishing detection fires on requestFullscreen calls
- [ ] Verify clipboard read detection fires on navigator.clipboard.readText
- [ ] Verify geolocation detection fires on getCurrentPosition/watchPosition