### PR TITLE
feat: add fingerprinting detection hooks (Canvas, WebGL, Audio)

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -73,6 +73,9 @@ import {
   type FullscreenPhishingData,
   type ClipboardReadData,
   type GeolocationAccessedData,
+  type CanvasFingerprintData,
+  type WebGLFingerprintData,
+  type AudioFingerprintData,
 } from "@pleno-audit/background-services";
 import {
   createExtensionNetworkService,
@@ -476,6 +479,9 @@ handleNetworkInspection: (data, sender) => networkSecurityInspector.handleNetwor
     handleFullscreenPhishing: (data, sender) => securityEventHandlers.handleFullscreenPhishing(data as FullscreenPhishingData, sender),
     handleClipboardRead: (data, sender) => securityEventHandlers.handleClipboardRead(data as ClipboardReadData, sender),
     handleGeolocationAccessed: (data, sender) => securityEventHandlers.handleGeolocationAccessed(data as GeolocationAccessedData, sender),
+    handleCanvasFingerprint: (data, sender) => securityEventHandlers.handleCanvasFingerprint(data as CanvasFingerprintData, sender),
+    handleWebGLFingerprint: (data, sender) => securityEventHandlers.handleWebGLFingerprint(data as WebGLFingerprintData, sender),
+    handleAudioFingerprint: (data, sender) => securityEventHandlers.handleAudioFingerprint(data as AudioFingerprintData, sender),
     getCSPReports: cspReportingService.getCSPReports,
     generateCSPPolicy: cspReportingService.generateCSPPolicy,
     generateCSPPolicyByDomain: cspReportingService.generateCSPPolicyByDomain,

--- a/app/audit-extension/entrypoints/security-bridge.content.ts
+++ b/app/audit-extension/entrypoints/security-bridge.content.ts
@@ -273,6 +273,9 @@ export default defineContentScript({
       "__FULLSCREEN_PHISHING_DETECTED__",
       "__CLIPBOARD_READ_DETECTED__",
       "__GEOLOCATION_ACCESSED__",
+      "__CANVAS_FINGERPRINT_DETECTED__",
+      "__WEBGL_FINGERPRINT_DETECTED__",
+      "__AUDIO_FINGERPRINT_DETECTED__",
     ];
 
     for (const eventType of securityEvents) {

--- a/app/audit-extension/public/hooks/fingerprint-hooks.js
+++ b/app/audit-extension/public/hooks/fingerprint-hooks.js
@@ -1,0 +1,95 @@
+;(function() {
+  'use strict'
+  if (window.__PLENO_FINGERPRINT_HOOKS_INITIALIZED__) return
+  window.__PLENO_FINGERPRINT_HOOKS_INITIALIZED__ = true
+
+  var shared = window.__PLENO_HOOKS_SHARED__
+  if (!shared) return
+  var emitSecurityEvent = shared.emitSecurityEvent
+
+  // Canvas fingerprinting detection
+  var originalToDataURL = HTMLCanvasElement.prototype.toDataURL
+  var canvasCallCount = 0
+  var canvasCallResetTimer = null
+
+  HTMLCanvasElement.prototype.toDataURL = function() {
+    canvasCallCount++
+    if (canvasCallCount >= 2) {
+      emitSecurityEvent('__CANVAS_FINGERPRINT_DETECTED__', {
+        callCount: canvasCallCount,
+        canvasWidth: this.width,
+        canvasHeight: this.height,
+        timestamp: Date.now(),
+        pageUrl: location.href
+      })
+    }
+    if (!canvasCallResetTimer) {
+      canvasCallResetTimer = setTimeout(function() {
+        canvasCallCount = 0
+        canvasCallResetTimer = null
+      }, 5000)
+    }
+    return originalToDataURL.apply(this, arguments)
+  }
+
+  // WebGL fingerprinting detection
+  var webglDetected = false
+  var originalGetParameter = null
+
+  function hookWebGLGetParameter(gl) {
+    if (!originalGetParameter) {
+      originalGetParameter = gl.__proto__.getParameter
+    }
+    gl.__proto__.getParameter = function(pname) {
+      // RENDERER, VENDOR, or debug renderer info extension params
+      if (pname === 0x1F01 || pname === 0x1F00 || pname === 0x9245 || pname === 0x9246) {
+        if (!webglDetected) {
+          webglDetected = true
+          emitSecurityEvent('__WEBGL_FINGERPRINT_DETECTED__', {
+            parameter: pname,
+            timestamp: Date.now(),
+            pageUrl: location.href
+          })
+        }
+      }
+      return originalGetParameter.call(this, pname)
+    }
+  }
+
+  // Hook getContext to intercept WebGL creation
+  var originalGetContext = HTMLCanvasElement.prototype.getContext
+  HTMLCanvasElement.prototype.getContext = function(contextType) {
+    var ctx = originalGetContext.apply(this, arguments)
+    if (ctx && (contextType === 'webgl' || contextType === 'webgl2' || contextType === 'experimental-webgl')) {
+      hookWebGLGetParameter(ctx)
+    }
+    return ctx
+  }
+
+  // AudioContext fingerprinting detection
+  if (window.AudioContext || window.webkitAudioContext) {
+    var OriginalAudioContext = window.AudioContext || window.webkitAudioContext
+    var audioContextCount = 0
+
+    var NewAudioContext = function AudioContext(options) {
+      audioContextCount++
+      if (audioContextCount >= 1) {
+        emitSecurityEvent('__AUDIO_FINGERPRINT_DETECTED__', {
+          contextCount: audioContextCount,
+          sampleRate: options?.sampleRate,
+          timestamp: Date.now(),
+          pageUrl: location.href
+        })
+      }
+      if (options !== undefined) {
+        return new OriginalAudioContext(options)
+      }
+      return new OriginalAudioContext()
+    }
+    NewAudioContext.prototype = OriginalAudioContext.prototype
+    window.AudioContext = NewAudioContext
+    if (window.webkitAudioContext) {
+      window.webkitAudioContext = NewAudioContext
+    }
+  }
+})()

--- a/app/audit-extension/wxt.config.ts
+++ b/app/audit-extension/wxt.config.ts
@@ -58,10 +58,10 @@ export default defineConfig({
             },
       }),
       web_accessible_resources: isMV2
-        ? ["api-hooks.js", "hooks/websocket-hooks.js", "hooks/worker-hooks.js", "hooks/injection-hooks.js", "parquet_wasm_bg.wasm"]
+        ? ["api-hooks.js", "hooks/websocket-hooks.js", "hooks/worker-hooks.js", "hooks/injection-hooks.js", "hooks/fingerprint-hooks.js", "parquet_wasm_bg.wasm"]
         : [
             {
-              resources: ["api-hooks.js", "hooks/websocket-hooks.js", "hooks/worker-hooks.js", "hooks/injection-hooks.js", "parquet_wasm_bg.wasm"],
+              resources: ["api-hooks.js", "hooks/websocket-hooks.js", "hooks/worker-hooks.js", "hooks/injection-hooks.js", "hooks/fingerprint-hooks.js", "parquet_wasm_bg.wasm"],
               matches: ["<all_urls>"],
             },
           ],
@@ -88,6 +88,12 @@ export default defineConfig({
           },
           {
             js: ["hooks/injection-hooks.js"],
+            matches: ["<all_urls>"],
+            run_at: "document_start",
+            world: "MAIN",
+          },
+          {
+            js: ["hooks/fingerprint-hooks.js"],
             matches: ["<all_urls>"],
             run_at: "document_start",
             world: "MAIN",

--- a/packages/alerts/src/alert-builders.ts
+++ b/packages/alerts/src/alert-builders.ts
@@ -25,6 +25,9 @@ import type {
   XSSInjectionAlertDetails,
   DOMScrapingAlertDetails,
   SuspiciousDownloadAlertDetails,
+  CanvasFingerprintAlertDetails,
+  WebGLFingerprintAlertDetails,
+  AudioFingerprintAlertDetails,
 } from "./types.js";
 
 export interface CreateAlertInput {
@@ -805,4 +808,91 @@ const SUSPICIOUS_DOWNLOAD_ALERT_DEFINITION: AlertDefinition<
 
 export const buildSuspiciousDownloadAlert = createAlertBuilder(
   SUSPICIOUS_DOWNLOAD_ALERT_DEFINITION
+);
+
+export interface CanvasFingerprintAlertParams {
+  domain: string;
+  callCount: number;
+  canvasWidth: number;
+  canvasHeight: number;
+}
+
+const CANVAS_FINGERPRINT_ALERT_DEFINITION: AlertDefinition<
+  CanvasFingerprintAlertParams,
+  CanvasFingerprintAlertDetails
+> = {
+  category: "canvas_fingerprint",
+  detailsType: "canvas_fingerprint",
+  build: (params) => ({
+    severity: "high",
+    title: `Canvas指紋採取検出: ${params.domain}`,
+    description: `Canvas APIを${params.callCount}回呼び出してフィンガープリントを収集`,
+    domain: params.domain,
+    details: {
+      domain: params.domain,
+      callCount: params.callCount,
+      canvasWidth: params.canvasWidth,
+      canvasHeight: params.canvasHeight,
+    },
+  }),
+};
+
+export const buildCanvasFingerprintAlert = createAlertBuilder(
+  CANVAS_FINGERPRINT_ALERT_DEFINITION
+);
+
+export interface WebGLFingerprintAlertParams {
+  domain: string;
+  parameter: number;
+}
+
+const WEBGL_FINGERPRINT_ALERT_DEFINITION: AlertDefinition<
+  WebGLFingerprintAlertParams,
+  WebGLFingerprintAlertDetails
+> = {
+  category: "webgl_fingerprint",
+  detailsType: "webgl_fingerprint",
+  build: (params) => ({
+    severity: "high",
+    title: `WebGL指紋採取検出: ${params.domain}`,
+    description: "WebGLパラメータを取得してフィンガープリントを収集",
+    domain: params.domain,
+    details: {
+      domain: params.domain,
+      parameter: params.parameter,
+    },
+  }),
+};
+
+export const buildWebGLFingerprintAlert = createAlertBuilder(
+  WEBGL_FINGERPRINT_ALERT_DEFINITION
+);
+
+export interface AudioFingerprintAlertParams {
+  domain: string;
+  contextCount: number;
+  sampleRate?: number;
+}
+
+const AUDIO_FINGERPRINT_ALERT_DEFINITION: AlertDefinition<
+  AudioFingerprintAlertParams,
+  AudioFingerprintAlertDetails
+> = {
+  category: "audio_fingerprint",
+  detailsType: "audio_fingerprint",
+  build: (params) => ({
+    severity: "high",
+    title: `Audio指紋採取検出: ${params.domain}`,
+    description: `AudioContextを${params.contextCount}回生成してフィンガープリントを収集`,
+    domain: params.domain,
+    details: {
+      domain: params.domain,
+      contextCount: params.contextCount,
+      sampleRate: params.sampleRate,
+    },
+  }),
+};
+
+export const buildAudioFingerprintAlert = createAlertBuilder(
+  AUDIO_FINGERPRINT_ALERT_DEFINITION
 );

--- a/packages/alerts/src/alert-manager.ts
+++ b/packages/alerts/src/alert-manager.ts
@@ -31,6 +31,9 @@ import type {
   XSSInjectionAlertParams,
   DOMScrapingAlertParams,
   SuspiciousDownloadAlertParams,
+  CanvasFingerprintAlertParams,
+  WebGLFingerprintAlertParams,
+  AudioFingerprintAlertParams,
 } from "./alert-builders.js";
 import {
   buildNRDAlert,
@@ -49,6 +52,9 @@ import {
   buildXSSInjectionAlert,
   buildDOMScrapingAlert,
   buildSuspiciousDownloadAlert,
+  buildCanvasFingerprintAlert,
+  buildWebGLFingerprintAlert,
+  buildAudioFingerprintAlert,
 } from "./alert-builders.js";
 
 /**
@@ -334,6 +340,24 @@ export function createAlertManager(
     return createOptionalAlert(buildSuspiciousDownloadAlert(params));
   }
 
+  async function alertCanvasFingerprint(
+    params: CanvasFingerprintAlertParams
+  ): Promise<SecurityAlert | null> {
+    return createAlert(buildCanvasFingerprintAlert(params));
+  }
+
+  async function alertWebGLFingerprint(
+    params: WebGLFingerprintAlertParams
+  ): Promise<SecurityAlert | null> {
+    return createAlert(buildWebGLFingerprintAlert(params));
+  }
+
+  async function alertAudioFingerprint(
+    params: AudioFingerprintAlertParams
+  ): Promise<SecurityAlert | null> {
+    return createAlert(buildAudioFingerprintAlert(params));
+  }
+
   async function updateAlertStatus(
     alertId: string,
     status: AlertStatus
@@ -393,6 +417,9 @@ export function createAlertManager(
     alertXSSInjection,
     alertDOMScraping,
     alertSuspiciousDownload,
+    alertCanvasFingerprint,
+    alertWebGLFingerprint,
+    alertAudioFingerprint,
     updateAlertStatus,
     getAlerts,
     getAlertCount,

--- a/packages/alerts/src/types.ts
+++ b/packages/alerts/src/types.ts
@@ -33,7 +33,10 @@ export type AlertCategory =
   | "cookie_access" // Suspicious cookie access
   | "xss_injection" // XSS payload detected
   | "dom_scraping" // DOM scraping detected
-  | "suspicious_download"; // Suspicious file download
+  | "suspicious_download" // Suspicious file download
+  | "canvas_fingerprint" // Canvas fingerprinting detected
+  | "webgl_fingerprint" // WebGL fingerprinting detected
+  | "audio_fingerprint"; // AudioContext fingerprinting detected
 
 /**
  * Alert status
@@ -85,7 +88,10 @@ export type AlertDetails =
   | CookieAccessAlertDetails
   | XSSInjectionAlertDetails
   | DOMScrapingAlertDetails
-  | SuspiciousDownloadAlertDetails;
+  | SuspiciousDownloadAlertDetails
+  | CanvasFingerprintAlertDetails
+  | WebGLFingerprintAlertDetails
+  | AudioFingerprintAlertDetails;
 
 export interface NRDAlertDetails {
   type: "nrd";
@@ -253,6 +259,27 @@ export interface SuspiciousDownloadAlertDetails {
   extension: string;
   size: number;
   mimeType: string;
+}
+
+export interface CanvasFingerprintAlertDetails {
+  type: "canvas_fingerprint";
+  domain: string;
+  callCount: number;
+  canvasWidth: number;
+  canvasHeight: number;
+}
+
+export interface WebGLFingerprintAlertDetails {
+  type: "webgl_fingerprint";
+  domain: string;
+  parameter: number;
+}
+
+export interface AudioFingerprintAlertDetails {
+  type: "audio_fingerprint";
+  domain: string;
+  contextCount: number;
+  sampleRate?: number;
 }
 
 /**

--- a/packages/background-services/src/index.ts
+++ b/packages/background-services/src/index.ts
@@ -44,4 +44,7 @@ export {
   type FullscreenPhishingData,
   type ClipboardReadData,
   type GeolocationAccessedData,
+  type CanvasFingerprintData,
+  type WebGLFingerprintData,
+  type AudioFingerprintData,
 } from "./services/security-event-handlers.js";

--- a/packages/background-services/src/runtime-handlers/security-handlers.ts
+++ b/packages/background-services/src/runtime-handlers/security-handlers.ts
@@ -88,5 +88,17 @@ export function createSecurityEventHandlers(
       execute: (message, sender) => deps.handleGeolocationAccessed(message.data, sender),
       fallback: () => ({ success: false }),
     }],
+    ["CANVAS_FINGERPRINT_DETECTED", {
+      execute: (message, sender) => deps.handleCanvasFingerprint(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
+    ["WEBGL_FINGERPRINT_DETECTED", {
+      execute: (message, sender) => deps.handleWebGLFingerprint(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
+    ["AUDIO_FINGERPRINT_DETECTED", {
+      execute: (message, sender) => deps.handleAudioFingerprint(message.data, sender),
+      fallback: () => ({ success: false }),
+    }],
   ];
 }

--- a/packages/background-services/src/runtime-handlers/types.ts
+++ b/packages/background-services/src/runtime-handlers/types.ts
@@ -107,6 +107,9 @@ handleNetworkInspection: (data: unknown, sender: chrome.runtime.MessageSender) =
   handleFullscreenPhishing: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleClipboardRead: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
   handleGeolocationAccessed: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleCanvasFingerprint: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleWebGLFingerprint: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
+  handleAudioFingerprint: (data: unknown, sender: chrome.runtime.MessageSender) => Promise<unknown>;
 
   getCSPReports: (options?: {
     type?: "csp-violation" | "network-request";

--- a/packages/background-services/src/services/security-event-handlers.ts
+++ b/packages/background-services/src/services/security-event-handlers.ts
@@ -171,6 +171,30 @@ export interface GeolocationAccessedData {
   pageUrl?: string;
 }
 
+export interface CanvasFingerprintData {
+  source?: string;
+  callCount?: number;
+  canvasWidth?: number;
+  canvasHeight?: number;
+  timestamp?: number;
+  pageUrl?: string;
+}
+
+export interface WebGLFingerprintData {
+  source?: string;
+  parameter?: number;
+  timestamp?: number;
+  pageUrl?: string;
+}
+
+export interface AudioFingerprintData {
+  source?: string;
+  contextCount?: number;
+  sampleRate?: number;
+  timestamp?: number;
+  pageUrl?: string;
+}
+
 interface SecurityEventHandlerDependencies {
   addEvent: (event: AuditEventInput) => Promise<unknown>;
   getAlertManager: () => AlertManager;
@@ -867,6 +891,123 @@ export function createSecurityEventHandlers(
           domain: pageDomain,
           method: data.method,
           highAccuracy: data.highAccuracy,
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleCanvasFingerprint(
+      data: CanvasFingerprintData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl || "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "canvas_fingerprint_detected",
+      });
+
+      await deps.addEvent({
+        type: "canvas_fingerprint_detected",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          callCount: data.callCount,
+          canvasWidth: data.canvasWidth,
+          canvasHeight: data.canvasHeight,
+          pageUrl: data.pageUrl,
+        },
+      });
+
+      await deps.getAlertManager().alertCanvasFingerprint({
+        domain: pageDomain,
+        callCount: data.callCount ?? 0,
+        canvasWidth: data.canvasWidth ?? 0,
+        canvasHeight: data.canvasHeight ?? 0,
+      });
+
+      deps.logger.warn({
+        event: "SECURITY_CANVAS_FINGERPRINT_DETECTED",
+        data: {
+          source: sourceLabel(data.source),
+          domain: pageDomain,
+          callCount: data.callCount,
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleWebGLFingerprint(
+      data: WebGLFingerprintData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl || "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "webgl_fingerprint_detected",
+      });
+
+      await deps.addEvent({
+        type: "webgl_fingerprint_detected",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          parameter: data.parameter,
+          pageUrl: data.pageUrl,
+        },
+      });
+
+      await deps.getAlertManager().alertWebGLFingerprint({
+        domain: pageDomain,
+        parameter: data.parameter ?? 0,
+      });
+
+      deps.logger.warn({
+        event: "SECURITY_WEBGL_FINGERPRINT_DETECTED",
+        data: {
+          source: sourceLabel(data.source),
+          domain: pageDomain,
+          parameter: data.parameter,
+        },
+      });
+
+      return { success: true };
+    },
+
+    async handleAudioFingerprint(
+      data: AudioFingerprintData,
+      sender: chrome.runtime.MessageSender,
+    ): Promise<{ success: boolean }> {
+      const pageDomain = resolvePageDomain(sender, data.pageUrl || "", deps.extractDomainFromUrl);
+      const eventTimestamp = resolveEventTimestamp(data.timestamp, {
+        logger: deps.logger,
+        context: "audio_fingerprint_detected",
+      });
+
+      await deps.addEvent({
+        type: "audio_fingerprint_detected",
+        domain: pageDomain,
+        timestamp: eventTimestamp,
+        details: {
+          contextCount: data.contextCount,
+          sampleRate: data.sampleRate,
+          pageUrl: data.pageUrl,
+        },
+      });
+
+      await deps.getAlertManager().alertAudioFingerprint({
+        domain: pageDomain,
+        contextCount: data.contextCount ?? 0,
+        sampleRate: data.sampleRate,
+      });
+
+      deps.logger.warn({
+        event: "SECURITY_AUDIO_FINGERPRINT_DETECTED",
+        data: {
+          source: sourceLabel(data.source),
+          domain: pageDomain,
+          contextCount: data.contextCount,
         },
       });
 


### PR DESCRIPTION
## Summary
- Add MAIN world fingerprint-hooks.js to detect Canvas (toDataURL), WebGL (getParameter for RENDERER/VENDOR), and AudioContext fingerprinting attempts
- Wire events through security-bridge content script to background service handlers and alert system
- Add three new alert categories (canvas_fingerprint, webgl_fingerprint, audio_fingerprint) with Japanese alert titles

## Test plan
- [x] All 1894 unit tests pass (`pnpm test`)
- [x] Extension builds successfully (`pnpm -C app/audit-extension build`)
- [x] `hooks/fingerprint-hooks.js` included in build output (3.09 KB)
- [ ] Manual: load extension, visit a page that uses canvas fingerprinting, verify alert fires
- [ ] Manual: visit WebGL demo page, verify WebGL fingerprint alert fires
- [ ] Manual: visit page creating AudioContext, verify audio fingerprint alert fires