### PR TITLE
feat: achieve Grade D (43/100) - Spectre/WebRTC/Beacon blocking

### DIFF
--- a/app/audit-extension/public/api-hooks.js
+++ b/app/audit-extension/public/api-hooks.js
@@ -322,7 +322,13 @@
     navigator.sendBeacon = function(url, data) {
       try {
         const fullUrl = new URL(url, window.location.origin).href
+        const parsed = new URL(fullUrl)
+        const isExternal = parsed.hostname !== location.hostname
         scheduleNetworkInspection({ url: fullUrl, method: 'POST', initiator: 'beacon', body: data, pageUrl: window.location.href })
+        // Block external beacon requests (data exfiltration prevention)
+        if (isExternal) {
+          return false
+        }
       } catch {}
       return originalSendBeacon(url, data)
     }

--- a/app/audit-extension/public/hooks/fingerprint-hooks.js
+++ b/app/audit-extension/public/hooks/fingerprint-hooks.js
@@ -87,6 +87,27 @@
     }
   }
 
+  // Reduce performance.now() precision to prevent timing attacks (Spectre mitigation)
+  var originalNow = performance.now.bind(performance)
+  performance.now = function() {
+    // Round to 0.1ms (100μs) to prevent high-precision timing attacks
+    return Math.round(originalNow() * 10) / 10
+  }
+
+  // Block RTCPeerConnection (prevents WebRTC data exfiltration)
+  if (window.RTCPeerConnection) {
+    var OriginalRTCPeerConnection = window.RTCPeerConnection
+    window.RTCPeerConnection = function() {
+      emitSecurityEvent('__WEBRTC_BLOCKED__', {
+        blocked: true,
+        timestamp: Date.now(),
+        pageUrl: location.href
+      })
+      throw new DOMException('RTCPeerConnection blocked by security policy', 'NotAllowedError')
+    }
+    window.RTCPeerConnection.prototype = OriginalRTCPeerConnection.prototype
+  }
+
   // BroadcastChannel side-channel blocking
   if (window.BroadcastChannel) {
     var OriginalBroadcastChannel = window.BroadcastChannel

--- a/app/battacker-e2e/defense-score-report.json
+++ b/app/battacker-e2e/defense-score-report.json
@@ -1,17 +1,17 @@
 {
-  "timestamp": "2026-03-17T14:26:02.478Z",
-  "totalScore": 35,
-  "grade": "F",
+  "timestamp": "2026-03-17T14:28:06.513Z",
+  "totalScore": 43,
+  "grade": "D",
   "testsRun": 60,
-  "blocked": 18,
+  "blocked": 21,
   "categories": [
     {
       "category": "side-channel",
       "label": "Side-Channel Attacks",
-      "score": 50,
+      "score": 80,
       "maxScore": 90,
-      "pct": 56,
-      "blocked": 3,
+      "pct": 89,
+      "blocked": 4,
       "total": 5,
       "weight": 0.12
     },
@@ -48,10 +48,10 @@
     {
       "category": "covert",
       "label": "Covert Channel Attacks",
-      "score": 30,
+      "score": 90,
       "maxScore": 120,
-      "pct": 25,
-      "blocked": 1,
+      "pct": 75,
+      "blocked": 3,
       "total": 5,
       "weight": 0.08
     },
@@ -163,7 +163,7 @@
       "category": "network",
       "severity": "high",
       "blocked": false,
-      "executionTime": 936.8000000715256,
+      "executionTime": 1046.2,
       "details": "Beacon sent (status: 200)"
     },
     {
@@ -172,7 +172,7 @@
       "category": "network",
       "severity": "critical",
       "blocked": false,
-      "executionTime": 192.60000002384186,
+      "executionTime": 303.9000000000001,
       "details": "Exfiltration simulated (status: 200)"
     },
     {
@@ -181,7 +181,7 @@
       "category": "network",
       "severity": "critical",
       "blocked": false,
-      "executionTime": 481.90000009536743,
+      "executionTime": 530.0999999999999,
       "details": "C2 polling successful, received 275 bytes"
     },
     {
@@ -190,7 +190,7 @@
       "category": "network",
       "severity": "critical",
       "blocked": true,
-      "executionTime": 0.30000007152557373,
+      "executionTime": 0.20000000000027285,
       "details": "WebSocket blocked: WebSocket connection to external host blocked by security policy"
     },
     {
@@ -199,7 +199,7 @@
       "category": "network",
       "severity": "critical",
       "blocked": true,
-      "executionTime": 0.3999999761581421,
+      "executionTime": 0.3000000000001819,
       "details": "Worker exfil blocked: Blob Worker creation blocked by security policy"
     },
     {
@@ -208,7 +208,7 @@
       "category": "phishing",
       "severity": "high",
       "blocked": false,
-      "executionTime": 0.3999999761581421,
+      "executionTime": 0.3000000000001819,
       "details": "Clipboard hijack successful"
     },
     {
@@ -217,7 +217,7 @@
       "category": "phishing",
       "severity": "high",
       "blocked": false,
-      "executionTime": 0.3999999761581421,
+      "executionTime": 0.3999999999996362,
       "details": "No stored credentials found"
     },
     {
@@ -226,7 +226,7 @@
       "category": "phishing",
       "severity": "medium",
       "blocked": true,
-      "executionTime": 0.30000007152557373,
+      "executionTime": 0.20000000000027285,
       "details": "Notification permission denied"
     },
     {
@@ -235,7 +235,7 @@
       "category": "client-side",
       "severity": "critical",
       "blocked": false,
-      "executionTime": 0.10000002384185791,
+      "executionTime": 0.09999999999990905,
       "details": "XSS-like injection successful"
     },
     {
@@ -244,7 +244,7 @@
       "category": "client-side",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 0,
+      "executionTime": 0.09999999999990905,
       "details": "DOM access: 1 forms, 2 inputs"
     },
     {
@@ -253,7 +253,7 @@
       "category": "client-side",
       "severity": "high",
       "blocked": false,
-      "executionTime": 0.20000004768371582,
+      "executionTime": 0.20000000000027285,
       "details": "Cookie access: 0 chars"
     },
     {
@@ -262,7 +262,7 @@
       "category": "download",
       "severity": "high",
       "blocked": false,
-      "executionTime": 0.5,
+      "executionTime": 0.29999999999972715,
       "details": "Blob URL download link created"
     },
     {
@@ -289,7 +289,7 @@
       "category": "persistence",
       "severity": "high",
       "blocked": false,
-      "executionTime": 17.100000023841858,
+      "executionTime": 17,
       "details": "IndexedDB data stash successful"
     },
     {
@@ -298,7 +298,7 @@
       "category": "persistence",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 2,
+      "executionTime": 1.699999999999818,
       "details": "Cache API abuse successful"
     },
     {
@@ -307,7 +307,7 @@
       "category": "persistence",
       "severity": "low",
       "blocked": false,
-      "executionTime": 0.20000004768371582,
+      "executionTime": 0.1999999999998181,
       "details": "History state exfil successful"
     },
     {
@@ -316,7 +316,7 @@
       "category": "side-channel",
       "severity": "medium",
       "blocked": true,
-      "executionTime": 0.6999999284744263,
+      "executionTime": 0.6999999999998181,
       "details": "Canvas fingerprinting returned empty data"
     },
     {
@@ -325,7 +325,7 @@
       "category": "side-channel",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 0,
+      "executionTime": 0.2000000000007276,
       "details": "Performance timing: 4 metrics collected"
     },
     {
@@ -342,9 +342,9 @@
       "name": "Spectre Timing Mitigation Check",
       "category": "side-channel",
       "severity": "critical",
-      "blocked": false,
-      "executionTime": 0.09999990463256836,
-      "details": "High-precision timer available - resolution 0.000000ms"
+      "blocked": true,
+      "executionTime": 0.1000000000003638,
+      "details": "Spectre mitigation active - resolution 0.100ms"
     },
     {
       "id": "side-channel-sharedarraybuffer",
@@ -361,7 +361,7 @@
       "category": "fingerprinting",
       "severity": "high",
       "blocked": true,
-      "executionTime": 3.899999976158142,
+      "executionTime": 4,
       "details": "WebGL blocked: WebGL fingerprinting blocked by security policy"
     },
     {
@@ -379,7 +379,7 @@
       "category": "fingerprinting",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 9.399999976158142,
+      "executionTime": 5.600000000000364,
       "details": "Font fingerprint: 10/10 fonts detected"
     },
     {
@@ -397,7 +397,7 @@
       "category": "fingerprinting",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 0.09999990463256836,
+      "executionTime": 0,
       "details": "Navigator fingerprint: 6 properties collected"
     },
     {
@@ -407,7 +407,7 @@
       "severity": "high",
       "blocked": false,
       "executionTime": 200,
-      "details": "CPU mining: 3282870 h/s (656574 hashes)"
+      "details": "CPU mining: 3424040 h/s (684808 hashes)"
     },
     {
       "id": "cryptojacking-worker",
@@ -415,7 +415,7 @@
       "category": "cryptojacking",
       "severity": "critical",
       "blocked": true,
-      "executionTime": 0.19999992847442627,
+      "executionTime": 0.3000000000001819,
       "details": "Worker mining blocked: Blob Worker creation blocked by security policy"
     },
     {
@@ -424,7 +424,7 @@
       "category": "cryptojacking",
       "severity": "critical",
       "blocked": true,
-      "executionTime": 0.19999992847442627,
+      "executionTime": 0.2999999999992724,
       "details": "Multi-worker mining blocked: Blob Worker creation blocked by security policy"
     },
     {
@@ -433,8 +433,8 @@
       "category": "cryptojacking",
       "severity": "high",
       "blocked": false,
-      "executionTime": 100.29999995231628,
-      "details": "WASM mining: 458400000 ops/s"
+      "executionTime": 100.19999999999982,
+      "details": "WASM mining: 449090000 ops/s"
     },
     {
       "id": "privacy-geolocation",
@@ -442,7 +442,7 @@
       "category": "privacy",
       "severity": "critical",
       "blocked": true,
-      "executionTime": 0.3999999761581421,
+      "executionTime": 0.5,
       "details": "Geolocation permission denied"
     },
     {
@@ -451,8 +451,8 @@
       "category": "privacy",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 0,
-      "details": "Battery: 87% (charging)"
+      "executionTime": 0.1999999999998181,
+      "details": "Battery: 89% (charging)"
     },
     {
       "id": "privacy-motion",
@@ -460,7 +460,7 @@
       "category": "privacy",
       "severity": "high",
       "blocked": false,
-      "executionTime": 18.399999976158142,
+      "executionTime": 19.399999999999636,
       "details": "Motion data: x=undefined"
     },
     {
@@ -469,7 +469,7 @@
       "category": "privacy",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 206,
+      "executionTime": 191.90000000000055,
       "details": "Media devices: 1 cameras, 1 mics"
     },
     {
@@ -478,7 +478,7 @@
       "category": "privacy",
       "severity": "low",
       "blocked": false,
-      "executionTime": 0.19999992847442627,
+      "executionTime": 0.0999999999994543,
       "details": "Storage: 0.00MB used of 136.96GB"
     },
     {
@@ -487,7 +487,7 @@
       "category": "media",
       "severity": "critical",
       "blocked": false,
-      "executionTime": 3002.0999999046326,
+      "executionTime": 3002.2,
       "details": "Screen capture permission pending"
     },
     {
@@ -496,7 +496,7 @@
       "category": "media",
       "severity": "critical",
       "blocked": true,
-      "executionTime": 59.40000009536743,
+      "executionTime": 54.5,
       "details": "Audio capture blocked"
     },
     {
@@ -505,7 +505,7 @@
       "category": "media",
       "severity": "critical",
       "blocked": true,
-      "executionTime": 33.800000071525574,
+      "executionTime": 29,
       "details": "Media capture blocked"
     },
     {
@@ -514,7 +514,7 @@
       "category": "storage",
       "severity": "high",
       "blocked": false,
-      "executionTime": 0.2999999523162842,
+      "executionTime": 0.3000000000001819,
       "details": "localStorage exfil: 52 bytes"
     },
     {
@@ -523,7 +523,7 @@
       "category": "storage",
       "severity": "high",
       "blocked": false,
-      "executionTime": 2.200000047683716,
+      "executionTime": 1.4000000000005457,
       "details": "sessionStorage exfil: 65 bytes"
     },
     {
@@ -532,7 +532,7 @@
       "category": "storage",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 101.40000009536743,
+      "executionTime": 102.20000000000073,
       "details": "Storage event listener set (single-tab test)"
     },
     {
@@ -550,7 +550,7 @@
       "category": "worker",
       "severity": "critical",
       "blocked": false,
-      "executionTime": 3,
+      "executionTime": 2.800000000000182,
       "details": "SharedWorker communication successful"
     },
     {
@@ -560,7 +560,7 @@
       "severity": "critical",
       "blocked": true,
       "executionTime": 0.5,
-      "details": "Service Worker blocked: Failed to register a ServiceWorker: The URL protocol of the script ('blob:http://127.0.0.1:56954/7d2cfb09-4764-4858-a582-6f80169ae795') is not supported."
+      "details": "Service Worker blocked: Failed to register a ServiceWorker: The URL protocol of the script ('blob:http://127.0.0.1:56995/778ec622-2f1f-4dc3-b31c-b0f62643db33') is not supported."
     },
     {
       "id": "worker-spawning-chain",
@@ -568,7 +568,7 @@
       "category": "worker",
       "severity": "high",
       "blocked": true,
-      "executionTime": 0.20000004768371582,
+      "executionTime": 0.3000000000001819,
       "details": "Worker chain blocked: Blob Worker creation blocked by security policy"
     },
     {
@@ -577,7 +577,7 @@
       "category": "injection",
       "severity": "high",
       "blocked": true,
-      "executionTime": 12.5,
+      "executionTime": 9.900000000000546,
       "details": "Clipboard read blocked: Failed to execute 'readText' on 'Clipboard': Read permission denied."
     },
     {
@@ -586,7 +586,7 @@
       "category": "injection",
       "severity": "critical",
       "blocked": false,
-      "executionTime": 0.7000000476837158,
+      "executionTime": 0.6000000000003638,
       "details": "Fullscreen takeover successful"
     },
     {
@@ -595,7 +595,7 @@
       "category": "injection",
       "severity": "high",
       "blocked": false,
-      "executionTime": 0.7000000476837158,
+      "executionTime": 0.2000000000007276,
       "details": "innerHTML injection: dangerous elements persisted"
     },
     {
@@ -612,9 +612,9 @@
       "name": "Beacon API Data Exfiltration",
       "category": "covert",
       "severity": "critical",
-      "blocked": false,
-      "executionTime": 0.5,
-      "details": "Beacon API exfiltration successful"
+      "blocked": true,
+      "executionTime": 0.1999999999998181,
+      "details": "Beacon API call failed"
     },
     {
       "id": "covert-dns-prefetch-leak",
@@ -622,7 +622,7 @@
       "category": "covert",
       "severity": "high",
       "blocked": false,
-      "executionTime": 101.70000004768372,
+      "executionTime": 102.59999999999945,
       "details": "DNS prefetch leak: covert channel established"
     },
     {
@@ -631,7 +631,7 @@
       "category": "covert",
       "severity": "critical",
       "blocked": true,
-      "executionTime": 2.100000023841858,
+      "executionTime": 1.8999999999996362,
       "details": "WebTransport blocked: Opening handshake failed."
     },
     {
@@ -639,9 +639,9 @@
       "name": "WebRTC DataChannel P2P",
       "category": "covert",
       "severity": "critical",
-      "blocked": false,
-      "executionTime": 3085.2999999523163,
-      "details": "WebRTC DataChannel timed out"
+      "blocked": true,
+      "executionTime": 0.1000000000003638,
+      "details": "WebRTC blocked: RTCPeerConnection blocked by security policy"
     },
     {
       "id": "covert-image-load-timing",
@@ -649,8 +649,8 @@
       "category": "covert",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 1361.5999999046326,
-      "details": "Image timing channel: avg 591ms"
+      "executionTime": 1902.5,
+      "details": "Image timing channel: avg 863ms"
     },
     {
       "id": "advanced-form-submit-hijack",
@@ -658,7 +658,7 @@
       "category": "advanced",
       "severity": "high",
       "blocked": false,
-      "executionTime": 0.19999992847442627,
+      "executionTime": 0.2000000000007276,
       "details": "Form submission hijacking successful"
     },
     {
@@ -676,7 +676,7 @@
       "category": "advanced",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 1349.6000000238419,
+      "executionTime": 172,
       "details": "Request header injection: custom headers sent"
     },
     {
@@ -685,7 +685,7 @@
       "category": "advanced",
       "severity": "high",
       "blocked": true,
-      "executionTime": 0.20000004768371582,
+      "executionTime": 0.3000000000010914,
       "details": "MutationObserver XSS blocked"
     },
     {
@@ -694,8 +694,8 @@
       "category": "advanced",
       "severity": "medium",
       "blocked": false,
-      "executionTime": 720.3999999761581,
-      "details": "CORS preflight timing: 720ms"
+      "executionTime": 826.4000000000015,
+      "details": "CORS preflight timing: 826ms"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Purple Team演習 最終フェーズ: Grade D (40+) 達成

追加防御:
- `performance.now()` 精度を0.1msに削減 (Spectre timing mitigation)
- `RTCPeerConnection` ブロック (WebRTC data exfiltration prevention)
- `sendBeacon` 外部ホスト向けブロック (data exfiltration prevention)

**Score: 43/100 (Grade D)** - 21/60 attacks blocked

## Test plan
- [x] defense-score.test.ts: 60 passed, score=43, grade=D