### PR TITLE
chore: reduce dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,20 +3,19 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
-      dev-dependencies:
-        dependency-type: development
-      production-dependencies:
-        dependency-type: production
+      all-dependencies:
+        patterns:
+          - "*"
     commit-message:
       prefix: chore
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: chore
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary
- Dependabot更新頻度をweeklyからmonthlyに変更
- npm依存をdev/productionの2グループから1グループに統合（月1PR）
- PR上限を削減（npm: 10→5, actions: 5→3）

セキュリティアラートは即時PRが維持されるため影響なし。