### PR TITLE
chore: group dependabot by risk level for auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,12 @@ updates:
     schedule:
       interval: monthly
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: chore
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- minor/patch更新を1つのグループPRにまとめ、auto-merge成功率を維持
- major更新はグループ外＝個別PRとして作成され、手動レビュー対象に隔離
- 全依存1グループだと1つのbreaking changeが全体をブロックする問題を解消

## Context
#365 で全依存を1グループにしたが、auto-merge成功率低下のリスクがあったため修正。