### PR TITLE
fix: rename StorageAdapter to QueueAdapter to avoid WXT unimport collision

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -73,7 +73,7 @@ import {
   createExtensionNetworkService,
   type ExtensionStats,
 } from "@pleno-audit/extension-network-service";
-import { createConsumer, type StorageAdapter, type QueueItem } from "@pleno-audit/event-queue";
+import { createConsumer, type QueueAdapter, type QueueItem } from "@pleno-audit/event-queue";
 
 const DEV_REPORT_ENDPOINT = "http://localhost:3001/api/v1/reports";
 
@@ -365,7 +365,7 @@ function initializeBackgroundServices(): void {
     .catch((error) => logger.error("Extension monitor init failed:", error));
 }
 
-const queueStorageAdapter: StorageAdapter = {
+const queueQueueAdapter: QueueAdapter = {
   get: (keys) => chrome.storage.local.get(keys),
   set: (items) => chrome.storage.local.set(items),
   remove: (keys) => chrome.storage.local.remove(keys),
@@ -493,7 +493,7 @@ export default defineBackground(() => {
   // Event Queue Consumer
   // ============================================================================
 
-  const eventQueueConsumer = createConsumer(queueStorageAdapter);
+  const eventQueueConsumer = createConsumer(queueQueueAdapter);
 
   const runtimeHandlers = createRuntimeMessageHandlersModule(
     createRuntimeHandlerDependencies(),

--- a/app/audit-extension/entrypoints/content.ts
+++ b/app/audit-extension/entrypoints/content.ts
@@ -11,7 +11,7 @@ import {
   type CookieBannerResult,
 } from "@pleno-audit/detectors";
 import { browserAdapter, createLogger } from "@pleno-audit/extension-runtime";
-import { createProducer, type StorageAdapter } from "@pleno-audit/event-queue";
+import { createProducer, type QueueAdapter } from "@pleno-audit/event-queue";
 
 const logger = createLogger("content");
 
@@ -22,7 +22,7 @@ const findTermsOfService = createTosFinder(browserAdapter);
 const findCookiePolicy = createCookiePolicyFinder(browserAdapter);
 const findCookieBanner = createCookieBannerFinder(browserAdapter);
 
-const storageAdapter: StorageAdapter = {
+const queueAdapter: QueueAdapter = {
   get: (keys) => chrome.storage.local.get(keys),
   set: (items) => chrome.storage.local.set(items),
   remove: (keys) => chrome.storage.local.remove(keys),
@@ -109,7 +109,7 @@ export default defineContentScript({
   main() {
     // Content scripts have a stable tab ID available via runtime
     const tabId = Date.now() % 1_000_000;
-    const producer = createProducer(storageAdapter, tabId);
+    const producer = createProducer(queueAdapter, tabId);
     producer.setContext({ senderUrl: window.location.href });
 
     if (document.readyState === "complete") {

--- a/app/audit-extension/entrypoints/csp.content.ts
+++ b/app/audit-extension/entrypoints/csp.content.ts
@@ -5,9 +5,9 @@
  */
 
 import type { CSPViolation } from "@pleno-audit/csp";
-import { createProducer, type StorageAdapter } from "@pleno-audit/event-queue";
+import { createProducer, type QueueAdapter } from "@pleno-audit/event-queue";
 
-const storageAdapter: StorageAdapter = {
+const queueAdapter: QueueAdapter = {
   get: (keys) => chrome.storage.local.get(keys),
   set: (items) => chrome.storage.local.set(items),
   remove: (keys) => chrome.storage.local.remove(keys),
@@ -26,7 +26,7 @@ export default defineContentScript({
   runAt: "document_start",
   main() {
     const tabId = Date.now() % 1_000_000;
-    const producer = createProducer(storageAdapter, tabId);
+    const producer = createProducer(queueAdapter, tabId);
     producer.setContext({ senderUrl: document.location.href });
 
     // Listen for CSP violation events

--- a/app/audit-extension/entrypoints/security-bridge.content.ts
+++ b/app/audit-extension/entrypoints/security-bridge.content.ts
@@ -5,11 +5,11 @@
  */
 
 import { createLogger } from "@pleno-audit/extension-runtime";
-import { createProducer, type StorageAdapter, type Priority } from "@pleno-audit/event-queue";
+import { createProducer, type QueueAdapter, type Priority } from "@pleno-audit/event-queue";
 
 const logger = createLogger("security-bridge");
 
-const storageAdapter: StorageAdapter = {
+const queueAdapter: QueueAdapter = {
   get: (keys) => chrome.storage.local.get(keys),
   set: (items) => chrome.storage.local.set(items),
   remove: (keys) => chrome.storage.local.remove(keys),
@@ -40,7 +40,7 @@ export default defineContentScript({
       if (!producer) {
         // Use a stable ID derived from runtime. Content scripts don't have sender.tab.id,
         // so we use a combination that's unique per content script instance.
-        producer = createProducer(storageAdapter, tabId);
+        producer = createProducer(queueAdapter, tabId);
         producer.setContext({ senderUrl: window.location.href });
       }
       return producer;

--- a/packages/event-queue/src/consumer.test.ts
+++ b/packages/event-queue/src/consumer.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createConsumer } from "./consumer.js";
-import type { StorageAdapter, QueueItem } from "./types.js";
+import type { QueueAdapter, QueueItem } from "./types.js";
 import { QUEUE_KEY_PREFIX } from "./types.js";
 
-function createMockStorage(): StorageAdapter & { data: Record<string, unknown> } {
+function createMockStorage(): QueueAdapter & { data: Record<string, unknown> } {
   const data: Record<string, unknown> = {};
   return {
     data,

--- a/packages/event-queue/src/consumer.ts
+++ b/packages/event-queue/src/consumer.ts
@@ -9,7 +9,7 @@
 import {
   type QueueItem,
   type ConsumerConfig,
-  type StorageAdapter,
+  type QueueAdapter,
   QUEUE_KEY_PREFIX,
   DEFAULTS,
 } from "./types.js";
@@ -29,19 +29,19 @@ export interface Consumer {
 }
 
 export function createConsumer(
-  storage: StorageAdapter,
+  adapter: QueueAdapter,
   config?: ConsumerConfig,
 ): Consumer {
   const chunkSize = config?.chunkSize ?? DEFAULTS.chunkSize;
 
   async function getAllQueueKeys(): Promise<string[]> {
-    const all = await storage.get(null);
+    const all = await adapter.get(null);
     return Object.keys(all).filter((k) => k.startsWith(QUEUE_KEY_PREFIX));
   }
 
   return {
     async process(handler: ProcessFn): Promise<ProcessResult> {
-      const all = await storage.get(null);
+      const all = await adapter.get(null);
       const keys = Object.keys(all).filter((k) => k.startsWith(QUEUE_KEY_PREFIX));
 
       let processed = 0;
@@ -82,9 +82,9 @@ export function createConsumer(
         remaining += rest.length;
 
         if (rest.length === 0) {
-          await storage.remove(key);
+          await adapter.remove(key);
         } else {
-          await storage.set({ [key]: rest });
+          await adapter.set({ [key]: rest });
         }
       }
 
@@ -97,14 +97,14 @@ export function createConsumer(
       const orphanKeys = keys.filter((k) => !activeSet.has(k));
 
       if (orphanKeys.length > 0) {
-        await storage.remove(orphanKeys);
+        await adapter.remove(orphanKeys);
       }
 
       return orphanKeys.length;
     },
 
     async pending(): Promise<number> {
-      const all = await storage.get(null);
+      const all = await adapter.get(null);
       let count = 0;
       for (const [key, value] of Object.entries(all)) {
         if (key.startsWith(QUEUE_KEY_PREFIX) && Array.isArray(value)) {

--- a/packages/event-queue/src/index.ts
+++ b/packages/event-queue/src/index.ts
@@ -10,5 +10,5 @@ export type {
   Priority,
   ProducerConfig,
   ConsumerConfig,
-  StorageAdapter,
+  QueueAdapter,
 } from "./types.js";

--- a/packages/event-queue/src/producer.test.ts
+++ b/packages/event-queue/src/producer.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createProducer } from "./producer.js";
-import type { StorageAdapter, QueueItem } from "./types.js";
+import type { QueueAdapter, QueueItem } from "./types.js";
 import { QUEUE_KEY_PREFIX } from "./types.js";
 
-function createMockStorage(): StorageAdapter & { data: Record<string, unknown> } {
+function createMockStorage(): QueueAdapter & { data: Record<string, unknown> } {
   const data: Record<string, unknown> = {};
   return {
     data,

--- a/packages/event-queue/src/producer.ts
+++ b/packages/event-queue/src/producer.ts
@@ -10,7 +10,7 @@ import {
   type QueueItem,
   type Priority,
   type ProducerConfig,
-  type StorageAdapter,
+  type QueueAdapter,
   QUEUE_KEY_PREFIX,
   DEFAULTS,
 } from "./types.js";
@@ -33,7 +33,7 @@ export interface Producer {
 }
 
 export function createProducer(
-  storage: StorageAdapter,
+  adapter: QueueAdapter,
   tabId: number,
   config?: ProducerConfig,
 ): Producer {
@@ -53,7 +53,7 @@ export function createProducer(
   }
 
   async function readQueue(): Promise<QueueItem[]> {
-    const data = await storage.get(key);
+    const data = await adapter.get(key);
     return (data[key] as QueueItem[] | undefined) ?? [];
   }
 
@@ -84,7 +84,7 @@ export function createProducer(
 
         queue.push(item);
         queue = applyBackpressure(queue);
-        await storage.set({ [key]: queue });
+        await adapter.set({ [key]: queue });
       });
     },
 
@@ -108,7 +108,7 @@ export function createProducer(
         }
 
         queue = applyBackpressure(queue);
-        await storage.set({ [key]: queue });
+        await adapter.set({ [key]: queue });
       });
     },
 

--- a/packages/event-queue/src/types.ts
+++ b/packages/event-queue/src/types.ts
@@ -37,10 +37,10 @@ export interface ConsumerConfig {
 }
 
 /**
- * Minimal storage adapter interface.
+ * Minimal queue persistence adapter.
  * Abstracts chrome.storage.local for testability.
  */
-export interface StorageAdapter {
+export interface QueueAdapter {
   get(keys: string | string[] | null): Promise<Record<string, unknown>>;
   set(items: Record<string, unknown>): Promise<void>;
   remove(keys: string | string[]): Promise<void>;


### PR DESCRIPTION
## Summary

- `StorageAdapter` → `QueueAdapter`、`storage` → `adapter`、`storageAdapter` → `queueAdapter` にリネーム
- WXT unimport pluginが `imports: false` でもworkspaceパッケージのソースを変換してしまうバグの回避 (wxt-dev/wxt#2206)

## Test plan

- [x] `pnpm build` 成功
- [x] `pnpm vitest run packages/event-queue` 全19テストパス