### PR TITLE
fix: resolve runtime safety issues and modernize TS config

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -579,7 +579,11 @@ export default defineBackground(() => {
     }
     const handler = alarmHandlers.get(alarm.name);
     if (handler) {
-      handler();
+      try {
+        handler();
+      } catch (error) {
+        logger.error(`Alarm handler "${alarm.name}" failed:`, error);
+      }
     }
   });
 

--- a/app/audit-extension/entrypoints/content.ts
+++ b/app/audit-extension/entrypoints/content.ts
@@ -108,7 +108,7 @@ export default defineContentScript({
   runAt: "document_idle",
   main() {
     // Content scripts have a stable tab ID available via runtime
-    const tabId = Date.now() % 1_000_000;
+    const tabId = crypto.getRandomValues(new Uint32Array(1))[0];
     const producer = createProducer(queueAdapter, tabId);
     producer.setContext({ senderUrl: window.location.href });
 

--- a/app/audit-extension/entrypoints/dashboard/state/useDashboardState.ts
+++ b/app/audit-extension/entrypoints/dashboard/state/useDashboardState.ts
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import type { CSPReport, CSPViolation, NetworkRequest } from "@pleno-audit/csp";
 import type { CapturedAIPrompt, DetectedService, EventLog } from "@pleno-audit/detectors";
+import { createLogger } from "@pleno-audit/extension-runtime";
 import type { Notification } from "../../../components/NotificationBanner";
 import type { Period, TabType, TotalCounts } from "../types";
 import { getThreatNotification, isThreatEventType } from "../domain/events";
 import { getPeriodMs, getStatusBadge } from "../utils";
+
+const logger = createLogger("dashboard-state");
 
 interface UseDashboardStateOptions {
   period: Period;
@@ -45,7 +48,7 @@ export function useDashboardState({
           return (await chrome.runtime.sendMessage(msg)) ?? fallback;
         } catch (error) {
           const type = (msg as { type?: string }).type ?? "unknown";
-          console.warn(`[dashboard] Runtime message failed: ${type}`, error);
+          logger.warn(`[dashboard] Runtime message failed: ${type}`, error);
           return fallback;
         }
       };
@@ -71,7 +74,7 @@ export function useDashboardState({
         safeMessage({ type: "GET_CONNECTION_CONFIG" }, { mode: "local" }),
         safeMessage({ type: "GET_AI_PROMPTS" }, []),
         chrome.storage.local.get(["services"]).catch((error) => {
-          console.warn("[dashboard] Failed to load services from chrome.storage.", error);
+          logger.warn("[dashboard] Failed to load services from chrome.storage.", error);
           return { services: {} };
         }),
         safeMessage({ type: "GET_EVENTS", data: { since: sinceTs, limit: 500 } }, { events: [], total: 0 }),
@@ -111,7 +114,7 @@ export function useDashboardState({
       }
       setLastUpdated(new Date().toISOString());
     } catch (error) {
-      console.warn("[dashboard] Failed to load dashboard data.", error);
+      logger.warn("[dashboard] Failed to load dashboard data.", error);
     } finally {
       setLoading(false);
       setIsRefreshing(false);
@@ -120,8 +123,22 @@ export function useDashboardState({
 
   useEffect(() => {
     loadData();
-    const interval = setInterval(loadData, 30000);
-    return () => clearInterval(interval);
+    let interval = setInterval(loadData, 30000);
+
+    function handleVisibilityChange() {
+      if (document.hidden) {
+        clearInterval(interval);
+      } else {
+        loadData();
+        interval = setInterval(loadData, 30000);
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
   }, [loadData]);
 
   useEffect(() => {

--- a/app/audit-extension/entrypoints/security-bridge.content.ts
+++ b/app/audit-extension/entrypoints/security-bridge.content.ts
@@ -25,7 +25,7 @@ export default defineContentScript({
   matches: ["<all_urls>"],
   runAt: "document_start",
   main() {
-    const tabId = chrome.runtime.id ? (Date.now() % 1_000_000) : 0;
+    const tabId = chrome.runtime.id ? crypto.getRandomValues(new Uint32Array(1))[0] : 0;
     const MAX_QUEUE = 200;
     const MAX_UNLOAD_BATCH = 50;
     const queue: RuntimeEvent[] = [];

--- a/packages/event-queue/src/producer.ts
+++ b/packages/event-queue/src/producer.ts
@@ -18,7 +18,8 @@ import {
 let idCounter = 0;
 
 function generateId(): string {
-  return `${Date.now()}-${idCounter++}-${Math.random().toString(36).slice(2, 6)}`;
+  const random = crypto.getRandomValues(new Uint32Array(1))[0];
+  return `${Date.now()}-${idCounter++}-${random.toString(36)}`;
 }
 
 export interface ProducerContext {
@@ -41,6 +42,7 @@ export function createProducer(
   const evictionThreshold = Math.floor(
     maxPerTab * (config?.evictionThreshold ?? DEFAULTS.evictionThreshold),
   );
+  const onEviction = config?.onEviction;
   const key = `${QUEUE_KEY_PREFIX}${tabId}`;
   let senderUrl: string | undefined;
 
@@ -58,11 +60,16 @@ export function createProducer(
   }
 
   function applyBackpressure(queue: QueueItem[]): QueueItem[] {
+    const beforeLen = queue.length;
     if (queue.length >= evictionThreshold) {
       queue = queue.filter((item) => item.priority !== "low");
+      const evicted = beforeLen - queue.length;
+      if (evicted > 0) onEviction?.(evicted, "low-priority");
     }
     if (queue.length >= maxPerTab) {
-      queue = queue.slice(queue.length - maxPerTab + 1);
+      const evicted = queue.length - maxPerTab + 1;
+      queue = queue.slice(evicted);
+      if (evicted > 0) onEviction?.(evicted, "overflow");
     }
     return queue;
   }

--- a/packages/event-queue/src/types.ts
+++ b/packages/event-queue/src/types.ts
@@ -29,6 +29,8 @@ export interface ProducerConfig {
   maxPerTab?: number;
   /** Threshold (0-1) at which low-priority items are evicted. Default: 0.8 */
   evictionThreshold?: number;
+  /** Called when events are evicted due to backpressure */
+  onEviction?: (evictedCount: number, reason: "low-priority" | "overflow") => void;
 }
 
 export interface ConsumerConfig {

--- a/packages/extension-runtime/package.json
+++ b/packages/extension-runtime/package.json
@@ -6,6 +6,23 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./logger": "./src/logger.ts",
+    "./storage": "./src/storage.ts",
+    "./storage-types": "./src/storage-types.ts",
+    "./network": "./src/network-monitor.ts",
+    "./blocking": "./src/blocking-engine.ts",
+    "./cooldown": "./src/cooldown-manager.ts",
+    "./browser": "./src/browser-adapter.ts",
+    "./sync": "./src/sync-manager.ts",
+    "./api": "./src/api-client.ts",
+    "./cookie": "./src/cookie-monitor.ts",
+    "./stats": "./src/extension-stats-analyzer.ts",
+    "./risk": "./src/extension-risk-analyzer.ts",
+    "./suspicious": "./src/suspicious-pattern-detector.ts",
+    "./doh": "./src/doh-monitor.ts",
+    "./sso": "./src/sso-manager.ts",
+    "./enterprise": "./src/enterprise-manager.ts",
+    "./errors": "./src/errors.ts",
     "./offscreen": "./src/offscreen/index.ts"
   },
   "dependencies": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,9 +6,8 @@
     "lib": ["ES2022"],
     "strict": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "noFallthroughCasesInSwitch": true
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,12 +11,50 @@ export default defineConfig({
       reporter: ["text", "json", "html"],
       include: ["packages/*/src/**/*.ts"],
       exclude: ["**/*.test.ts", "**/*.spec.ts", "**/index.ts"],
-      // Initial thresholds based on current coverage. Ratchet up as test coverage improves.
       thresholds: {
-        lines: 30,
-        functions: 40,
-        branches: 40,
-        statements: 30,
+        // Per-package thresholds: detection packages hold 90%+, others ratcheted to current levels
+        "packages/nrd/src/**": {
+          lines: 95,
+          functions: 95,
+          branches: 95,
+          statements: 95,
+        },
+        "packages/typosquat/src/**": {
+          lines: 95,
+          functions: 95,
+          branches: 95,
+          statements: 95,
+        },
+        "packages/detectors/src/**": {
+          lines: 90,
+          functions: 90,
+          branches: 85,
+          statements: 90,
+        },
+        "packages/event-queue/src/**": {
+          lines: 95,
+          functions: 90,
+          branches: 90,
+          statements: 95,
+        },
+        "packages/ai-detector/src/**": {
+          lines: 70,
+          functions: 70,
+          branches: 60,
+          statements: 70,
+        },
+        "packages/data-export/src/**": {
+          lines: 75,
+          functions: 65,
+          branches: 65,
+          statements: 75,
+        },
+        "packages/extension-runtime/src/**": {
+          lines: 40,
+          functions: 50,
+          branches: 40,
+          statements: 40,
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

mizchi氏視点でのコードレビューにより発見された技術負債・バグを修正。

### P0 (バグ修正)
- **Tab ID衝突**: `Date.now() % 1_000_000` → `crypto.getRandomValues()` (content.ts, security-bridge.content.ts, producer.ts)
- **alarm handler未保護**: bare `handler()` → try-catch保護 (background.ts) — MV3 SW crash防止

### P1 (品質改善)
- **console.warn違反**: `console.warn` → `createLogger("dashboard-state")` (useDashboardState.ts)
- **非アクティブタブポーリング**: `visibilitychange`でダッシュボードの30秒ポーリングを停止/再開
- **eviction無通知**: `onEviction`コールバックをProducerConfigに追加 — サイレントイベントドロップを可視化

### 基盤改善
- `extension-runtime`に17のsubpath exports追加（依存の明示性向上）
- `isolatedModules` → `verbatimModuleSyntax`移行（TS 5.9+）
- テストカバレッジ閾値をパッケージ別に設定（検出系95%、ランタイム系40%）

## Test plan
- [x] `pnpm typecheck` — pass
- [x] `pnpm test` — 58 files, 1765 tests pass
- [x] `pnpm build` — 441 KB, pass