### PR TITLE
refactor: zero-dependency @libztbs/types foundation

### DIFF
--- a/lib/ai-detector/package.json
+++ b/lib/ai-detector/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@libztbs/alerts": "workspace:*"
+    "@libztbs/alerts": "workspace:*",
+    "@libztbs/types": "workspace:*"
   }
 }

--- a/lib/ai-detector/src/provider-classifier.ts
+++ b/lib/ai-detector/src/provider-classifier.ts
@@ -5,31 +5,8 @@
  * Shadow AI検出強化の一環として、より多くのプロバイダーをサポート。
  */
 
-import type { InferredProvider } from "./types.js";
-
-// ============================================================================
-// Extended Provider Type
-// ============================================================================
-
-/**
- * 拡張AIプロバイダー（既存+新規）
- */
-export type ExtendedProvider =
-  | InferredProvider
-  | "azure" // Azure OpenAI
-  | "cohere" // Cohere
-  | "mistral" // Mistral AI
-  | "meta" // Meta Llama
-  | "together" // Together.ai
-  | "replicate" // Replicate
-  | "huggingface" // Hugging Face
-  | "perplexity" // Perplexity
-  | "groq" // Groq
-  | "deepseek" // DeepSeek
-  | "moonshot" // Moonshot AI
-  | "zhipu" // Zhipu AI (智谱)
-  | "baidu" // Baidu ERNIE
-  | "alibaba"; // Alibaba Qwen
+import type { InferredProvider, ExtendedProvider } from "@libztbs/types";
+export type { ExtendedProvider } from "@libztbs/types";
 
 /**
  * プロバイダー分類結果

--- a/lib/ai-detector/src/types.ts
+++ b/lib/ai-detector/src/types.ts
@@ -6,12 +6,8 @@
 // AI Service Detection（AIサービス検出）
 // ============================================================================
 
-/** 推定されたAIプロバイダー */
-export type InferredProvider =
-  | "openai" // ChatGPT, API
-  | "anthropic" // Claude
-  | "google" // Gemini
-  | "unknown"; // 汎用検出
+import type { InferredProvider } from "@libztbs/types";
+export type { InferredProvider } from "@libztbs/types";
 
 /** AI検出方法 */
 export type AIDetectionMethod =

--- a/lib/types/package.json
+++ b/lib/types/package.json
@@ -7,9 +7,5 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "dependencies": {
-    "@libztbs/ai-detector": "workspace:*",
-    "@libztbs/csp": "workspace:*",
-    "@libztbs/typosquat": "workspace:*"
-  }
+  "dependencies": {}
 }

--- a/lib/types/src/index.ts
+++ b/lib/types/src/index.ts
@@ -1,14 +1,38 @@
 /**
- * @fileoverview CASB Domain Types
+ * @fileoverview Zero Trust Browser Security — Core Types
  *
- * Cloud Access Security Broker (CASB) ドメインの型定義。
- * SaaSサービスの可視化とリスク評価を担う。
+ * libztbsの基盤型定義。全パッケージはこのパッケージの型に依存可能。
+ * このパッケージ自体はゼロ依存。
  */
 
-import type {
-  InferredProvider,
-  ExtendedProvider,
-} from "@libztbs/ai-detector";
+// ============================================================================
+// AI Provider Types
+// ============================================================================
+
+/** 推定されたAIプロバイダー */
+export type InferredProvider =
+  | "openai" // ChatGPT, API
+  | "anthropic" // Claude
+  | "google" // Gemini
+  | "unknown"; // 汎用検出
+
+/** 拡張AIプロバイダー（既存+新規） */
+export type ExtendedProvider =
+  | InferredProvider
+  | "azure" // Azure OpenAI
+  | "cohere" // Cohere
+  | "mistral" // Mistral AI
+  | "meta" // Meta Llama
+  | "together" // Together.ai
+  | "replicate" // Replicate
+  | "huggingface" // Hugging Face
+  | "perplexity" // Perplexity
+  | "groq" // Groq
+  | "deepseek" // DeepSeek
+  | "moonshot" // Moonshot AI
+  | "zhipu" // Zhipu AI (智谱)
+  | "baidu" // Baidu ERNIE
+  | "alibaba"; // Alibaba Qwen
 
 // ============================================================================
 // SaaS Visibility (サービス可視性)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       '@libztbs/alerts':
         specifier: workspace:*
         version: link:../alerts
+      '@libztbs/types':
+        specifier: workspace:*
+        version: link:../types
 
   lib/alerts: {}
 
@@ -324,17 +327,7 @@ importers:
 
   lib/nrd: {}
 
-  lib/types:
-    dependencies:
-      '@libztbs/ai-detector':
-        specifier: workspace:*
-        version: link:../ai-detector
-      '@libztbs/csp':
-        specifier: workspace:*
-        version: link:../csp
-      '@libztbs/typosquat':
-        specifier: workspace:*
-        version: link:../typosquat
+  lib/types: {}
 
   lib/typosquat: {}
 


### PR DESCRIPTION
## Summary

- `InferredProvider`, `ExtendedProvider`型を`@libztbs/ai-detector`から`@libztbs/types`に移動
- `@libztbs/types`がゼロ依存となり、依存グラフの最下層に正しく位置

### Before
```
@libztbs/types → @libztbs/ai-detector, @libztbs/csp, @libztbs/typosquat  (逆依存!)
```

### After
```
@libztbs/types: []  (ゼロ依存 ✓)
@libztbs/ai-detector → @libztbs/alerts, @libztbs/types  (正しい方向)
```

## Test plan
- [x] typecheck passes
- [x] 1757 tests pass
- [ ] CI passes