### PR TITLE
feat(enterprise): add audit-enterprise admin web console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 dist/
 *.tsbuildinfo
+vite.config.d.ts
+vite.config.js
 .DS_Store
 *.log
 .wxt/

--- a/app/audit-enterprise/index.html
+++ b/app/audit-enterprise/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%23000'/><text x='50' y='70' text-anchor='middle' font-size='60' fill='white' font-family='sans-serif' font-weight='400'>P</text></svg>" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pleno ZTBS — Enterprise Console</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app/audit-enterprise/package.json
+++ b/app/audit-enterprise/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@libztbs/audit-enterprise",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "lucide-react": "^1.7.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^6.0.2",
+    "vite": "^8.0.3"
+  }
+}

--- a/app/audit-enterprise/src/App.tsx
+++ b/app/audit-enterprise/src/App.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { DATA } from "./data";
+import { AppHeader, Sidebar, type TabId } from "./components/shell";
+import { OverviewPage } from "./pages/Overview";
+import { GraphPage } from "./pages/Graph";
+import { AlertsPage, ExfilPage, IdentityPage, InvestigationPage } from "./pages/Detection";
+import { ExtensionsPage, FleetPage, PolicyPage, SaasPage } from "./pages/Posture";
+import { CompliancePage, IntegrationsPage } from "./pages/Governance";
+
+const STORAGE_KEY = "pleno-enterprise.tab";
+
+function App() {
+  const [tab, setTab] = useState<TabId>(() => {
+    const saved = typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+    return (saved as TabId) || "overview";
+  });
+  const [dark, setDark] = useState(true);
+
+  useEffect(() => {
+    if (typeof localStorage !== "undefined") localStorage.setItem(STORAGE_KEY, tab);
+  }, [tab]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark);
+  }, [dark]);
+
+  const data = DATA;
+
+  const page = (() => {
+    switch (tab) {
+      case "overview": return <OverviewPage data={data} riskViz="bar" />;
+      case "graph": return <GraphPage />;
+      case "alerts": return <AlertsPage data={data} />;
+      case "investigation": return <InvestigationPage />;
+      case "exfil": return <ExfilPage data={data} />;
+      case "identity": return <IdentityPage data={data} />;
+      case "fleet": return <FleetPage data={data} />;
+      case "extensions": return <ExtensionsPage data={data} />;
+      case "saas": return <SaasPage data={data} />;
+      case "policy": return <PolicyPage data={data} />;
+      case "compliance": return <CompliancePage data={data} />;
+      case "integrations": return <IntegrationsPage data={data} />;
+    }
+  })();
+
+  return (
+    <div className="app">
+      <AppHeader org={data.org} dark={dark} onDark={() => setDark(v => !v)} />
+      <div className="body">
+        <Sidebar active={tab} onChange={setTab} />
+        <main className="main" key={tab}>
+          {page}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/app/audit-enterprise/src/components/shell.tsx
+++ b/app/audit-enterprise/src/components/shell.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from "react";
+import type { OrgInfo } from "../data";
+import { Icon, IconButton } from "./ui";
+
+export type TabId =
+  | "overview" | "graph" | "alerts" | "investigation" | "exfil" | "identity"
+  | "fleet" | "extensions" | "saas" | "policy" | "compliance" | "integrations";
+
+type NavItem =
+  | { section: string; id?: never }
+  | { id: TabId; ja: string; en: string; icon: string; count?: number; variant?: string; hero?: boolean; section?: never };
+
+export const NAV: NavItem[] = [
+  { section: "Workspace" },
+  { id: "overview", ja: "概要", en: "Overview", icon: "layout-dashboard" },
+  { id: "graph", ja: "アセットグラフ", en: "Asset Graph", icon: "git-branch", hero: true },
+  { section: "Detection" },
+  { id: "alerts", ja: "アラート", en: "Alerts / BDR", icon: "siren", count: 14, variant: "danger" },
+  { id: "investigation", ja: "調査", en: "Forensics", icon: "search", count: 3, variant: "info" },
+  { id: "exfil", ja: "データ漏洩", en: "Exfil Monitor", icon: "upload-cloud" },
+  { id: "identity", ja: "アイデンティティ", en: "Identity", icon: "user-check" },
+  { section: "Posture" },
+  { id: "fleet", ja: "ブラウザ", en: "Fleet", icon: "monitor" },
+  { id: "extensions", ja: "拡張機能", en: "Extensions", icon: "puzzle" },
+  { id: "saas", ja: "SaaS & AI", en: "SaaS / AI", icon: "layers" },
+  { id: "policy", ja: "ポリシー", en: "Policy (CASB)", icon: "shield-check" },
+  { section: "Governance" },
+  { id: "compliance", ja: "コンプライアンス", en: "Compliance", icon: "file-check" },
+  { id: "integrations", ja: "連携", en: "Integrations", icon: "plug" },
+];
+
+export const Sidebar = ({ active, onChange }: { active: TabId; onChange: (id: TabId) => void }) => {
+  const ref = useRef<HTMLElement>(null);
+  const [ind, setInd] = useState({ top: 0, h: 0 });
+  useEffect(() => {
+    const el = ref.current?.querySelector(`[data-tab="${active}"]`) as HTMLElement | null;
+    if (el) setInd({ top: el.offsetTop, h: el.offsetHeight });
+  }, [active]);
+
+  return (
+    <nav className="sb" ref={ref}>
+      <div className="sb-ind" style={{ top: ind.top, height: ind.h }} />
+      {NAV.map((n, i) => {
+        if ("section" in n && n.section) {
+          return <div key={`s-${i}`} className="sb-section">{n.section}</div>;
+        }
+        if (!("id" in n) || !n.id) return null;
+        return (
+          <button
+            key={n.id}
+            data-tab={n.id}
+            className={`tab ${active === n.id ? "active" : ""}`}
+            onClick={() => onChange(n.id as TabId)}
+            type="button"
+          >
+            <Icon name={n.icon} size={14} color="muted" />
+            <span className="tab-label">{n.ja}</span>
+            {n.count != null && <span className={`tab-count ${n.variant || ""}`}>{n.count}</span>}
+            {n.hero && <Icon name="sparkles" size={10} color="muted" style={{ opacity: 0.5 }} />}
+          </button>
+        );
+      })}
+      <div className="sb-foot">
+        <div>ローカルファースト · 外部送信なし</div>
+        <div className="region">
+          <span className="dot" style={{ background: "var(--success)" }} />
+          <span>4リージョン · 正常</span>
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export const AppHeader = ({ org, dark, onDark }: {
+  org: OrgInfo; dark: boolean; onDark: () => void;
+}) => (
+  <header className="app-header">
+    <div className="brand">
+      <span className="brand-mark">P</span>
+      <span className="brand-name">Pleno</span>
+      <span className="brand-sub">ZTBS Console</span>
+    </div>
+    <div className="hd-search">
+      <Icon name="search" size={13} color="muted" />
+      <input placeholder="資産、ユーザー、CVE、ドメインを検索..." />
+      <span className="kbd">⌘K</span>
+    </div>
+    <div className="hd-right">
+      <div className="hd-status">
+        <span className="pulse" />
+        <span>リアルタイム監視中 · {org.lastUpdated}</span>
+      </div>
+      <IconButton icon="bell" title="通知" />
+      <IconButton icon={dark ? "sun" : "moon"} onClick={onDark} title="テーマ" />
+      <div className="hd-org">
+        <span className="avatar">{org.shortCode}</span>
+        <span>{org.name}</span>
+        <Icon name="chevrons-up-down" size={12} color="muted" />
+      </div>
+    </div>
+  </header>
+);

--- a/app/audit-enterprise/src/components/ui.tsx
+++ b/app/audit-enterprise/src/components/ui.tsx
@@ -1,0 +1,212 @@
+import type { CSSProperties, ReactNode } from "react";
+import {
+  Activity, AlertTriangle, ArrowRight, Ban, Bell, Book, BookOpen, ChevronRight, ChevronsUpDown,
+  Database, Download, ExternalLink, FileCheck, FileText, Filter, GitBranch, Info, Key, KeyRound,
+  Layers, LayoutDashboard, Maximize, MessageSquare, Monitor, Moon, Play, Plug, Plus, Puzzle,
+  RefreshCw, Rss, Search, Send, Settings, Share2, Shield, ShieldCheck, ShieldOff, Siren,
+  SkipBack, SkipForward, Smartphone, Sparkles, Sun, Tag, Upload, UploadCloud,
+  UserCheck, UserPlus, UserX, Workflow, ZoomIn, ZoomOut,
+  type LucideIcon,
+} from "lucide-react";
+import type { Severity } from "../data";
+
+const ICONS: Record<string, LucideIcon> = {
+  activity: Activity,
+  "alert-triangle": AlertTriangle,
+  "arrow-right": ArrowRight,
+  ban: Ban,
+  bell: Bell,
+  book: Book,
+  "book-open": BookOpen,
+  "chevron-right": ChevronRight,
+  "chevrons-up-down": ChevronsUpDown,
+  database: Database,
+  download: Download,
+  "external-link": ExternalLink,
+  "file-check": FileCheck,
+  "file-text": FileText,
+  filter: Filter,
+  "git-branch": GitBranch,
+  info: Info,
+  key: Key,
+  "key-round": KeyRound,
+  layers: Layers,
+  "layout-dashboard": LayoutDashboard,
+  maximize: Maximize,
+  "message-square": MessageSquare,
+  monitor: Monitor,
+  moon: Moon,
+  play: Play,
+  plug: Plug,
+  plus: Plus,
+  puzzle: Puzzle,
+  "refresh-cw": RefreshCw,
+  rss: Rss,
+  search: Search,
+  send: Send,
+  server: Database,
+  settings: Settings,
+  "share-2": Share2,
+  shield: Shield,
+  "shield-check": ShieldCheck,
+  "shield-off": ShieldOff,
+  siren: Siren,
+  "skip-back": SkipBack,
+  "skip-forward": SkipForward,
+  smartphone: Smartphone,
+  sparkles: Sparkles,
+  sun: Sun,
+  tag: Tag,
+  upload: Upload,
+  "upload-cloud": UploadCloud,
+  "user-check": UserCheck,
+  "user-plus": UserPlus,
+  "user-x": UserX,
+  workflow: Workflow,
+  "zoom-in": ZoomIn,
+  "zoom-out": ZoomOut,
+};
+
+export interface IconProps {
+  name: string;
+  size?: number;
+  color?: "muted" | string;
+  style?: CSSProperties;
+}
+
+export const Icon = ({ name, size = 14, color, style }: IconProps) => {
+  const LucideComp = ICONS[name] ?? Info;
+  const resolvedColor =
+    color === "muted"
+      ? "var(--muted-foreground)"
+      : color && color !== "currentColor"
+        ? color
+        : "currentColor";
+  return (
+    <LucideComp
+      size={size}
+      strokeWidth={1.75}
+      color={resolvedColor}
+      style={{ flexShrink: 0, verticalAlign: "middle", ...style }}
+    />
+  );
+};
+
+export type BadgeVariant = "default" | "success" | "warning" | "danger" | "info" | "accent";
+
+export const Badge = ({ variant = "default", children, style }: { variant?: BadgeVariant; children: ReactNode; style?: CSSProperties }) => (
+  <span className={`b ${variant}`} style={style}>{children}</span>
+);
+
+const SEV_MAP: Record<Severity, { v: BadgeVariant; t: string }> = {
+  critical: { v: "danger", t: "critical" },
+  high: { v: "danger", t: "high" },
+  medium: { v: "warning", t: "medium" },
+  low: { v: "info", t: "low" },
+  info: { v: "info", t: "info" },
+  safe: { v: "success", t: "safe" },
+};
+
+export const Sev = ({ level }: { level: Severity }) => {
+  const m = SEV_MAP[level] ?? SEV_MAP.info;
+  return <Badge variant={m.v}>{m.t}</Badge>;
+};
+
+export const Dot = ({ color = "var(--muted-foreground)", size = 8, style }: { color?: string; size?: number; style?: CSSProperties }) => (
+  <span className="dot" style={{ background: color, width: size, height: size, ...style }} />
+);
+
+export const Sparkline = ({ data, width = 80, height = 22, color = "var(--accent)", fill = false }: {
+  data: number[]; width?: number; height?: number; color?: string; fill?: boolean;
+}) => {
+  if (!data || data.length === 0) return null;
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+  const step = width / (data.length - 1);
+  const pts = data.map((d, i) => [i * step, height - ((d - min) / range) * (height - 2) - 1]);
+  const d = pts.map((p, i) => `${i === 0 ? "M" : "L"}${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(" ");
+  const area = fill ? `${d} L${width},${height} L0,${height} Z` : null;
+  return (
+    <svg width={width} height={height} style={{ display: "block", overflow: "visible" }}>
+      {area && <path d={area} fill={color} opacity="0.12" />}
+      <path d={d} stroke={color} strokeWidth="1.25" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+};
+
+export const RiskBarScore = ({ value, max = 100, color }: { value: number; max?: number; color?: string }) => {
+  const w = (value / max) * 100;
+  const c = color || (value >= 80 ? "var(--danger)" : value >= 60 ? "var(--warning)" : value >= 40 ? "var(--info)" : "var(--success)");
+  return (
+    <div style={{ position: "relative", height: 6, background: "var(--tertiary)", borderRadius: 3, overflow: "hidden" }}>
+      <div style={{ position: "absolute", left: 0, top: 0, bottom: 0, width: `${w}%`, background: c, borderRadius: 3 }} />
+    </div>
+  );
+};
+
+export const Heatmap = ({ data, cols = 14, rows = 6, cellSize = 12, gap = 2 }: {
+  data: number[]; cols?: number; rows?: number; cellSize?: number; gap?: number;
+}) => {
+  const maxN = cols * rows;
+  const cells = Array.from({ length: maxN }, (_, i) => data[i % data.length] || 0);
+  return (
+    <svg width={cols * (cellSize + gap)} height={rows * (cellSize + gap)}>
+      {cells.map((v, i) => {
+        const x = (i % cols) * (cellSize + gap);
+        const y = Math.floor(i / cols) * (cellSize + gap);
+        const op = 0.1 + v * 0.9;
+        const color = v > 0.7 ? "var(--danger)" : v > 0.4 ? "var(--warning)" : "var(--info)";
+        return <rect key={i} x={x} y={y} width={cellSize} height={cellSize} fill={color} opacity={op} rx={2} />;
+      })}
+    </svg>
+  );
+};
+
+export const Metric = ({ label, value, delta, unit, sub, spark }: {
+  label: string; value: number | string; delta?: number; unit?: string; sub?: string; spark?: number[];
+}) => {
+  const up = typeof delta === "number" && delta > 0;
+  const down = typeof delta === "number" && delta < 0;
+  return (
+    <div className="card" style={{ padding: 14, display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
+      <div className="metric-label">{label}</div>
+      <div className="row" style={{ alignItems: "baseline", justifyContent: "space-between" }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 4, minWidth: 0 }}>
+          <span className="metric-val tabular">{typeof value === "number" ? value.toLocaleString() : value}</span>
+          {unit && <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>{unit}</span>}
+        </div>
+        {spark && <Sparkline data={spark} width={64} height={20} />}
+      </div>
+      <div className="row" style={{ gap: 6, fontSize: 11, color: "var(--muted-foreground)" }}>
+        {delta !== undefined && (
+          <span className={`metric-delta ${up ? "up" : down ? "down" : ""}`}>
+            {up ? "▲" : down ? "▼" : "●"} {Math.abs(delta)}
+          </span>
+        )}
+        {sub && <span>{sub}</span>}
+      </div>
+    </div>
+  );
+};
+
+export const PageHeader = ({ title, kicker, sub, actions }: {
+  title: string; kicker?: string; sub?: string; actions?: ReactNode;
+}) => (
+  <div className="page-header">
+    <div>
+      <div className="title-row">
+        <h1 className="page-title">{title}</h1>
+        {kicker && <span className="page-kicker">{kicker}</span>}
+      </div>
+      {sub && <div className="page-sub">{sub}</div>}
+    </div>
+    {actions && <div className="page-actions">{actions}</div>}
+  </div>
+);
+
+export const IconButton = ({ icon, onClick, title }: { icon: string; onClick?: () => void; title?: string }) => (
+  <button className="icon-btn" onClick={onClick} title={title}>
+    <Icon name={icon} size={15} color="muted" />
+  </button>
+);

--- a/app/audit-enterprise/src/components/ui.tsx
+++ b/app/audit-enterprise/src/components/ui.tsx
@@ -120,8 +120,12 @@ export const Sparkline = ({ data, width = 80, height = 22, color = "var(--accent
   data: number[]; width?: number; height?: number; color?: string; fill?: boolean;
 }) => {
   if (!data || data.length === 0) return null;
-  const max = Math.max(...data);
-  const min = Math.min(...data);
+  let max = data[0];
+  let min = data[0];
+  for (const v of data) {
+    if (v > max) max = v;
+    if (v < min) min = v;
+  }
   const range = max - min || 1;
   const step = width / (data.length - 1);
   const pts = data.map((d, i) => [i * step, height - ((d - min) / range) * (height - 2) - 1]);

--- a/app/audit-enterprise/src/data.ts
+++ b/app/audit-enterprise/src/data.ts
@@ -1,0 +1,303 @@
+export type Severity = "critical" | "high" | "medium" | "low" | "info" | "safe";
+
+export interface OrgInfo {
+  name: string;
+  shortCode: string;
+  regions: string[];
+  managedBrowsers: number;
+  managedUsers: number;
+  activeSessions: number;
+  lastUpdated: string;
+}
+
+export interface RiskBreakdown {
+  label: string;
+  key: string;
+  score: number;
+  weight: number;
+}
+
+export interface RiskData {
+  score: number;
+  scoreDelta: number;
+  grade: string;
+  bands: { critical: number; high: number; medium: number; low: number; info: number };
+  breakdown: RiskBreakdown[];
+  trend: number[];
+}
+
+export interface Stats {
+  alerts24h: number;
+  alertsDelta: number;
+  blocked24h: number;
+  blockedDelta: number;
+  exfilEvents: number;
+  exfilDelta: number;
+  mttrMin: number;
+  mttrDelta: number;
+}
+
+export interface Threat {
+  id: string;
+  sev: Severity;
+  title: string;
+  count: number;
+  asset: string;
+  trend: number[];
+}
+
+export interface Browser {
+  id: string;
+  host: string;
+  user: string;
+  os: string;
+  browser: string;
+  risk: Severity;
+  alerts: number;
+  ext: number;
+  lastSeen: string;
+  region: string;
+  posture: string[];
+}
+
+export interface Alert {
+  id: string;
+  ts: string;
+  sev: Severity;
+  cat: string;
+  title: string;
+  asset: string;
+  dst: string;
+  state: string;
+}
+
+export interface Extension {
+  name: string;
+  id: string;
+  installs: number;
+  perms: string[];
+  risk: Severity;
+  status: string;
+  publisher: string;
+  firstSeen: string;
+  note: string;
+}
+
+export interface SaasApp {
+  name: string;
+  cat: string;
+  sanction: string;
+  users: number;
+  sensitivity: Severity;
+  exfil: number;
+  aiIngress: number;
+  risk: Severity;
+  trend: number[];
+}
+
+export interface IdentityEvent {
+  user: string;
+  risk: Severity;
+  event: string;
+  app: string;
+  ts: string;
+  detail: string;
+}
+
+export interface ExfilEvent {
+  ts: string;
+  actor: string;
+  channel: string;
+  dst: string;
+  kind: string;
+  bytes: string;
+  classes: string[];
+  action: string;
+}
+
+export interface Policy {
+  id: string;
+  name: string;
+  scope: string;
+  action: string;
+  hits24h: number;
+  last: string;
+  state: string;
+}
+
+export interface Integration {
+  name: string;
+  cat: string;
+  status: string;
+  events: string;
+  since: string;
+  icon: string;
+}
+
+export interface Compliance {
+  framework: string;
+  score: number;
+  controls: number;
+  passing: number;
+  failing: number;
+  partial: number;
+  audit: string;
+}
+
+export interface DashboardData {
+  org: OrgInfo;
+  risk: RiskData;
+  stats: Stats;
+  topThreats: Threat[];
+  browsers: Browser[];
+  alerts: Alert[];
+  extensions: Extension[];
+  saasApps: SaasApp[];
+  identity: IdentityEvent[];
+  exfilEvents: ExfilEvent[];
+  policies: Policy[];
+  integrations: Integration[];
+  compliance: Compliance[];
+}
+
+export const DATA: DashboardData = {
+  org: {
+    name: "Shinrai Holdings株式会社",
+    shortCode: "SH",
+    regions: ["APAC-TYO", "APAC-SIN", "NA-IAD", "EU-FRA"],
+    managedBrowsers: 58432,
+    managedUsers: 51204,
+    activeSessions: 41268,
+    lastUpdated: "2026/4/23 09:14:22 JST",
+  },
+
+  risk: {
+    score: 72,
+    scoreDelta: +4,
+    grade: "C+",
+    bands: { critical: 14, high: 87, medium: 342, low: 1204, info: 2891 },
+    breakdown: [
+      { label: "ブラウザ脆弱性", key: "vuln", score: 68, weight: 20 },
+      { label: "拡張機能リスク", key: "ext", score: 82, weight: 18 },
+      { label: "データ漏洩", key: "exfil", score: 58, weight: 22 },
+      { label: "アイデンティティ", key: "identity", score: 74, weight: 15 },
+      { label: "シャドーSaaS", key: "saas", score: 79, weight: 12 },
+      { label: "ポリシー違反", key: "policy", score: 71, weight: 13 },
+    ],
+    trend: [62, 64, 63, 65, 68, 67, 66, 68, 70, 71, 69, 70, 71, 72],
+  },
+
+  stats: {
+    alerts24h: 1843,
+    alertsDelta: -12,
+    blocked24h: 287,
+    blockedDelta: +34,
+    exfilEvents: 64,
+    exfilDelta: +8,
+    mttrMin: 14,
+    mttrDelta: -3,
+  },
+
+  topThreats: [
+    { id: "T-8842", sev: "critical", title: "CVE-2026-3091 V8型混乱 未パッチ", count: 1284, asset: "Chrome 131.x fleet", trend: [3, 5, 8, 11, 14, 18, 22, 28] },
+    { id: "T-8841", sev: "high", title: "OAuthトークン抜き出し: Notion → unknown-cdn.io", count: 47, asset: "notion.so", trend: [1, 2, 2, 3, 4, 6, 8, 11] },
+    { id: "T-8840", sev: "high", title: "悪質拡張機能検出: \"SuperTabs Pro\"", count: 212, asset: "Chrome Web Store", trend: [0, 0, 0, 2, 8, 31, 88, 212] },
+    { id: "T-8839", sev: "high", title: "機密情報をAIに送信: chatgpt.com (PII + 財務)", count: 318, asset: "chatgpt.com", trend: [12, 18, 25, 31, 38, 44, 52, 64] },
+    { id: "T-8838", sev: "medium", title: "大量ダウンロード検出: salesforce.com → ローカル", count: 21, asset: "salesforce.com", trend: [2, 3, 4, 5, 6, 7, 10, 12] },
+  ],
+
+  browsers: [
+    { id: "BR-0001", host: "takahashi-mbp.sh.jp", user: "takahashi.yui@sh.co.jp", os: "macOS 15.2", browser: "Chrome 131.0.6778.205", risk: "high", alerts: 18, ext: 32, lastSeen: "2分前", region: "APAC-TYO", posture: ["EDR✓", "ディスク暗号✓", "DLPエージェント✗"] },
+    { id: "BR-0002", host: "SH-DESK-4421", user: "kim.jihoon@sh.co.kr", os: "Windows 11", browser: "Edge 132.0.2957.127", risk: "medium", alerts: 7, ext: 14, lastSeen: "8分前", region: "APAC-SIN", posture: ["EDR✓", "ディスク暗号✓", "DLPエージェント✓"] },
+    { id: "BR-0003", host: "schmidt-dev.sh.de", user: "mara.schmidt@sh.de", os: "Ubuntu 24.04", browser: "Chrome 131.0.6778.205", risk: "high", alerts: 12, ext: 9, lastSeen: "15分前", region: "EU-FRA", posture: ["EDR✓", "ディスク暗号✗", "DLPエージェント✓"] },
+    { id: "BR-0004", host: "iad-finops-08", user: "priya.ramanan@sh.com", os: "Windows 11", browser: "Chrome 132.0.6834.83", risk: "low", alerts: 0, ext: 6, lastSeen: "1分前", region: "NA-IAD", posture: ["EDR✓", "ディスク暗号✓", "DLPエージェント✓"] },
+    { id: "BR-0005", host: "tyo-legal-03", user: "nakamura.kenji@sh.co.jp", os: "macOS 14.7", browser: "Chrome 130.0.6723.117", risk: "medium", alerts: 4, ext: 11, lastSeen: "22分前", region: "APAC-TYO", posture: ["EDR✓", "ディスク暗号✓", "DLPエージェント✓"] },
+    { id: "BR-0006", host: "sin-eng-tw-laptop", user: "wong.chenxi@sh.com.sg", os: "macOS 15.2", browser: "Brave 1.72.123", risk: "critical", alerts: 29, ext: 41, lastSeen: "4時間前", region: "APAC-SIN", posture: ["EDR✗", "ディスク暗号✓", "DLPエージェント✗"] },
+    { id: "BR-0007", host: "SH-DESK-1102", user: "o-brien.aisling@sh.com", os: "Windows 11", browser: "Chrome 131.0.6778.205", risk: "medium", alerts: 5, ext: 12, lastSeen: "6分前", region: "NA-IAD", posture: ["EDR✓", "ディスク暗号✓", "DLPエージェント✓"] },
+    { id: "BR-0008", host: "fra-data-02", user: "dubois.camille@sh.fr", os: "Ubuntu 24.04", browser: "Firefox 134.0", risk: "low", alerts: 1, ext: 3, lastSeen: "3分前", region: "EU-FRA", posture: ["EDR✓", "ディスク暗号✓", "DLPエージェント✓"] },
+  ],
+
+  alerts: [
+    { id: "A-14482", ts: "09:12:44", sev: "critical", cat: "BDR", title: "CVE-2026-3091 V8型混乱のエクスプロイト試行", asset: "BR-0006 · wong.chenxi@sh.com.sg", dst: "hxxps://unknown-cdn.io/sw.js", state: "新規" },
+    { id: "A-14481", ts: "09:11:18", sev: "high", cat: "Exfil", title: "機密データをAIに送信 (PII × 4, 財務 × 2)", asset: "BR-0001 · takahashi.yui", dst: "chatgpt.com", state: "トリアージ中" },
+    { id: "A-14480", ts: "09:10:52", sev: "high", cat: "Identity", title: "OAuth scope昇格: Notion Workspace Admin", asset: "BR-0007 · o-brien.aisling", dst: "notion.so", state: "新規" },
+    { id: "A-14479", ts: "09:09:40", sev: "high", cat: "Ext", title: "悪質拡張機能インストール: SuperTabs Pro", asset: "BR-0003 · mara.schmidt", dst: "chromewebstore.google.com", state: "新規" },
+    { id: "A-14478", ts: "09:08:12", sev: "medium", cat: "Policy", title: "DLPルール違反: PII貼り付け → claude.ai", asset: "BR-0002 · kim.jihoon", dst: "claude.ai", state: "ブロック済" },
+    { id: "A-14477", ts: "09:06:58", sev: "medium", cat: "Session", title: "異常な地理ログイン: TYO → LAX (4分)", asset: "BR-0005 · nakamura.kenji", dst: "login.microsoftonline.com", state: "調査中" },
+    { id: "A-14476", ts: "09:05:03", sev: "high", cat: "Exfil", title: "大量ダウンロード: salesforce.com (218MB)", asset: "BR-0006 · wong.chenxi", dst: "salesforce.com", state: "新規" },
+    { id: "A-14475", ts: "09:04:41", sev: "info", cat: "BDR", title: "WebRTC経由のローカルIP列挙", asset: "BR-0004 · priya.ramanan", dst: "x.com", state: "クローズ" },
+    { id: "A-14474", ts: "09:03:12", sev: "high", cat: "Ext", title: "<all_urls>権限の新規昇格: Grammarly", asset: "BR-0001 · takahashi.yui", dst: "grammarly.com", state: "トリアージ中" },
+    { id: "A-14473", ts: "09:02:05", sev: "critical", cat: "BDR", title: "Cookie窃取: document.cookie 読取 → 外部送信", asset: "BR-0006 · wong.chenxi", dst: "hxxps://unknown-cdn.io/c.gif", state: "新規" },
+  ],
+
+  extensions: [
+    { name: "SuperTabs Pro", id: "mpogaebdhgnbelh...", installs: 212, perms: ["<all_urls>", "cookies", "webRequest", "tabs", "storage"], risk: "critical", status: "禁止対象", publisher: "Unknown", firstSeen: "2026/4/21", note: "最近アップデートでマルウェア挙動追加" },
+    { name: "Grammarly", id: "kbfnbcaeplbcioak...", installs: 11204, perms: ["<all_urls>", "storage", "activeTab"], risk: "medium", status: "承認済", publisher: "Grammarly, Inc.", firstSeen: "2024/6/2", note: "" },
+    { name: "1Password", id: "aeblfdkhhhdcdjpi...", installs: 18332, perms: ["<all_urls>", "nativeMessaging", "storage"], risk: "low", status: "承認済", publisher: "AgileBits", firstSeen: "2023/11/18", note: "" },
+    { name: "Honey", id: "bmnlcjabgnpnenek...", installs: 4421, perms: ["<all_urls>", "cookies", "webRequest"], risk: "high", status: "レビュー中", publisher: "PayPal, Inc.", firstSeen: "2024/2/14", note: "アフィリエイト書換え挙動" },
+    { name: "Claude", id: "fmkadmapgofadopl...", installs: 8820, perms: ["<all_urls>", "debugger", "nativeMessaging"], risk: "medium", status: "条件付承認", publisher: "Anthropic", firstSeen: "2026/1/22", note: "debugger権限要注意" },
+    { name: "LastPass", id: "hdokiejnpimakedh...", installs: 2204, perms: ["<all_urls>", "storage"], risk: "medium", status: "非推奨", publisher: "LastPass US LP", firstSeen: "2022/3/10", note: "2022年侵害事件あり" },
+    { name: "Video DownloadHelper", id: "lmjnegcaeklhafol...", installs: 188, perms: ["<all_urls>", "downloads", "webRequest", "nativeMessaging"], risk: "high", status: "レビュー中", publisher: "mig", firstSeen: "2025/9/3", note: "" },
+  ],
+
+  saasApps: [
+    { name: "Salesforce", cat: "CRM", sanction: "承認済", users: 8204, sensitivity: "high", exfil: 38, aiIngress: 0, risk: "medium", trend: [200, 210, 220, 218, 230, 240, 255] },
+    { name: "Notion", cat: "Docs", sanction: "承認済", users: 22140, sensitivity: "high", exfil: 112, aiIngress: 48, risk: "high", trend: [180, 200, 220, 230, 240, 245, 250] },
+    { name: "ChatGPT", cat: "AI", sanction: "条件付", users: 31882, sensitivity: "critical", exfil: 284, aiIngress: 1284, risk: "critical", trend: [100, 150, 220, 310, 420, 530, 640] },
+    { name: "Claude", cat: "AI", sanction: "条件付", users: 18209, sensitivity: "critical", exfil: 182, aiIngress: 802, risk: "critical", trend: [80, 120, 180, 240, 320, 400, 480] },
+    { name: "Perplexity", cat: "AI", sanction: "未承認", users: 4418, sensitivity: "high", exfil: 88, aiIngress: 204, risk: "high", trend: [10, 30, 50, 80, 110, 130, 160] },
+    { name: "Figma", cat: "Design", sanction: "承認済", users: 2204, sensitivity: "medium", exfil: 14, aiIngress: 0, risk: "low", trend: [90, 92, 94, 96, 98, 100, 102] },
+    { name: "Dropbox", cat: "Storage", sanction: "承認済", users: 1018, sensitivity: "high", exfil: 42, aiIngress: 0, risk: "medium", trend: [40, 42, 44, 43, 45, 47, 48] },
+    { name: "Granola", cat: "AI Meet", sanction: "未承認", users: 188, sensitivity: "high", exfil: 24, aiIngress: 88, risk: "high", trend: [0, 2, 8, 14, 22, 30, 40] },
+    { name: "Personal Gmail", cat: "Email", sanction: "禁止", users: 442, sensitivity: "critical", exfil: 61, aiIngress: 0, risk: "critical", trend: [20, 22, 30, 38, 42, 48, 52] },
+  ],
+
+  identity: [
+    { user: "wong.chenxi@sh.com.sg", risk: "critical", event: "OAuth scope昇格", app: "Notion", ts: "09:10:52", detail: "read → workspace.admin" },
+    { user: "nakamura.kenji@sh.co.jp", risk: "high", event: "不可能な移動", app: "M365", ts: "09:06:58", detail: "TYO → LAX / 4分間" },
+    { user: "takahashi.yui@sh.co.jp", risk: "high", event: "MFAバイパス試行", app: "Okta", ts: "08:58:24", detail: "3回連続プッシュ疲労" },
+    { user: "priya.ramanan@sh.com", risk: "medium", event: "旧デバイスからのログイン", app: "Google", ts: "08:44:12", detail: "unknown-device-id-2281" },
+    { user: "kim.jihoon@sh.co.kr", risk: "medium", event: "セッショントークン更新", app: "GitHub", ts: "08:40:08", detail: "PAT拡張" },
+  ],
+
+  exfilEvents: [
+    { ts: "09:11:18", actor: "takahashi.yui", channel: "AIプロンプト", dst: "chatgpt.com", kind: "貼り付け", bytes: "2.4KB", classes: ["PII", "財務"], action: "許可 (監視)" },
+    { ts: "09:06:12", actor: "wong.chenxi", channel: "ダウンロード", dst: "salesforce.com→local", kind: "一括エクスポート", bytes: "218MB", classes: ["顧客"], action: "ブロック" },
+    { ts: "09:02:34", actor: "mara.schmidt", channel: "アップロード", dst: "dropbox.com", kind: "ファイル", bytes: "44MB", classes: ["ソース"], action: "ブロック" },
+    { ts: "08:58:02", actor: "kim.jihoon", channel: "貼り付け", dst: "claude.ai", kind: "貼り付け", bytes: "812B", classes: ["PII"], action: "ブロック" },
+    { ts: "08:52:44", actor: "o-brien", channel: "フォーム送信", dst: "unknown-cdn.io", kind: "POST", bytes: "1.2KB", classes: ["トークン"], action: "ブロック" },
+    { ts: "08:48:18", actor: "priya.ramanan", channel: "印刷", dst: "local", kind: "PDF化", bytes: "8.8MB", classes: ["顧客"], action: "許可 (監視)" },
+  ],
+
+  policies: [
+    { id: "P-001", name: "AI経由のPII漏洩防止", scope: "全ユーザー", action: "ブロック+通知", hits24h: 284, last: "09:11:18", state: "有効" },
+    { id: "P-002", name: "未承認SaaSへのログイン禁止", scope: "財務部", action: "ブロック", hits24h: 42, last: "08:44:21", state: "有効" },
+    { id: "P-003", name: "Salesforceからの一括エクスポート", scope: "営業部", action: "ブロック+承認", hits24h: 21, last: "09:05:03", state: "有効" },
+    { id: "P-004", name: "Cookie読取の監視", scope: "全ユーザー", action: "アラートのみ", hits24h: 182, last: "09:02:05", state: "有効" },
+    { id: "P-005", name: "危険権限拡張機能のブロック", scope: "全ユーザー", action: "ブロック", hits24h: 8, last: "08:20:11", state: "有効" },
+    { id: "P-006", name: "暗号資産取引所のブロック", scope: "財務部以外", action: "ブロック", hits24h: 3, last: "07:12:02", state: "有効" },
+    { id: "P-007", name: "個人メールへのリンク共有", scope: "全ユーザー", action: "警告+監視", hits24h: 61, last: "09:01:44", state: "下書き" },
+  ],
+
+  integrations: [
+    { name: "Splunk Enterprise", cat: "SIEM", status: "接続", events: "4.2M/日", since: "2024/8/2", icon: "Activity" },
+    { name: "CrowdStrike Falcon", cat: "EDR", status: "接続", events: "1.1M/日", since: "2024/11/18", icon: "Shield" },
+    { name: "Okta", cat: "IdP", status: "接続", events: "382K/日", since: "2024/6/10", icon: "Key" },
+    { name: "Palo Alto XSOAR", cat: "SOAR", status: "接続", events: "28K/日", since: "2025/3/22", icon: "Workflow" },
+    { name: "Microsoft Sentinel", cat: "SIEM", status: "接続", events: "2.1M/日", since: "2025/1/8", icon: "Activity" },
+    { name: "Azure AD (Entra)", cat: "IdP", status: "接続", events: "201K/日", since: "2024/4/1", icon: "Key" },
+    { name: "Jamf Pro", cat: "MDM", status: "接続", events: "12K/日", since: "2024/9/3", icon: "Smartphone" },
+    { name: "Slack", cat: "通知", status: "接続", events: "—", since: "2024/5/5", icon: "MessageSquare" },
+    { name: "PagerDuty", cat: "通知", status: "接続", events: "—", since: "2024/5/5", icon: "Bell" },
+    { name: "ServiceNow", cat: "ITSM", status: "未接続", events: "—", since: "—", icon: "Settings" },
+  ],
+
+  compliance: [
+    { framework: "SOC 2 Type II", score: 94, controls: 64, passing: 60, failing: 2, partial: 2, audit: "2026/6/15" },
+    { framework: "ISO 27001:2022", score: 89, controls: 93, passing: 82, failing: 4, partial: 7, audit: "2026/9/02" },
+    { framework: "GDPR", score: 91, controls: 48, passing: 43, failing: 1, partial: 4, audit: "継続" },
+    { framework: "NIST CSF 2.0", score: 81, controls: 108, passing: 88, failing: 6, partial: 14, audit: "継続" },
+    { framework: "HIPAA", score: 76, controls: 54, passing: 41, failing: 4, partial: 9, audit: "2026/8/10" },
+    { framework: "APPI (改正個人情報保護法)", score: 88, controls: 42, passing: 37, failing: 1, partial: 4, audit: "2026/5/30" },
+  ],
+};

--- a/app/audit-enterprise/src/main.tsx
+++ b/app/audit-enterprise/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./style.css";
+
+const root = document.getElementById("root");
+if (root) {
+  createRoot(root).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}

--- a/app/audit-enterprise/src/pages/Detection.tsx
+++ b/app/audit-enterprise/src/pages/Detection.tsx
@@ -1,0 +1,458 @@
+import { useState } from "react";
+import type { DashboardData, Severity } from "../data";
+import { Badge, Dot, Icon, Metric, PageHeader, RiskBarScore, Sev } from "../components/ui";
+
+export const AlertsPage = ({ data }: { data: DashboardData }) => {
+  const [selected, setSelected] = useState(data.alerts[0].id);
+  const [sev, setSev] = useState<"all" | Severity>("all");
+  const sel = data.alerts.find(a => a.id === selected);
+  const filtered = sev === "all" ? data.alerts : data.alerts.filter(a => a.sev === sev);
+  const counts = data.alerts.reduce<Record<string, number>>((acc, a) => {
+    acc[a.sev] = (acc[a.sev] || 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <>
+      <PageHeader
+        title="アラート & BDR"
+        kicker="BROWSER DETECTION & RESPONSE"
+        sub="ブラウザ内で発生した異常を一元化。Mandiant式のトリアージワークフローと対応アクションを統合。"
+        actions={<>
+          <button type="button" className="btn"><Icon name="filter" size={12} /> 高度フィルタ</button>
+          <button type="button" className="btn"><Icon name="rss" size={12} /> ライブ</button>
+          <button type="button" className="btn accent"><Icon name="plus" size={12} /> ケース作成</button>
+        </>}
+      />
+      <div className="page-body" style={{ padding: 0, display: "flex", flex: 1, minHeight: 0 }}>
+        <div style={{ width: 540, borderRight: "1px solid var(--border)", display: "flex", flexDirection: "column", background: "var(--background)" }}>
+          <div style={{ padding: "10px 16px", borderBottom: "1px solid var(--border)", display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+            <button type="button" className={`chip ${sev === "all" ? "active" : ""}`} onClick={() => setSev("all")}>全て ({data.alerts.length})</button>
+            <button type="button" className={`chip ${sev === "critical" ? "active" : ""}`} onClick={() => setSev("critical")}>
+              <Dot color="var(--danger)" size={6} /> critical ({counts.critical || 0})
+            </button>
+            <button type="button" className={`chip ${sev === "high" ? "active" : ""}`} onClick={() => setSev("high")}>
+              <Dot color="var(--warning)" size={6} /> high ({counts.high || 0})
+            </button>
+            <button type="button" className={`chip ${sev === "medium" ? "active" : ""}`} onClick={() => setSev("medium")}>medium ({counts.medium || 0})</button>
+            <button type="button" className={`chip ${sev === "info" ? "active" : ""}`} onClick={() => setSev("info")}>info ({counts.info || 0})</button>
+          </div>
+          <div style={{ overflow: "auto", flex: 1 }}>
+            {filtered.map(a => (
+              <div key={a.id}
+                onClick={() => setSelected(a.id)}
+                style={{
+                  padding: "12px 16px", borderBottom: "1px solid var(--border-light)", cursor: "pointer",
+                  background: selected === a.id ? "var(--secondary)" : "var(--background)",
+                  borderLeft: selected === a.id ? "2px solid var(--accent)" : "2px solid transparent",
+                }}>
+                <div className="row" style={{ gap: 6, marginBottom: 4 }}>
+                  <Sev level={a.sev} />
+                  <Badge variant="info">{a.cat}</Badge>
+                  <span className="spacer" />
+                  <span className="mono muted" style={{ fontSize: 11 }}>{a.id} · {a.ts}</span>
+                </div>
+                <div style={{ fontSize: 13, fontWeight: 500, marginBottom: 3 }}>{a.title}</div>
+                <div className="muted" style={{ fontSize: 11 }}>{a.asset}</div>
+                <div className="row" style={{ marginTop: 6, gap: 6 }}>
+                  <Badge variant={a.state === "ブロック済" ? "success" : a.state === "新規" ? "danger" : "default"}>{a.state}</Badge>
+                  <span className="muted mono" style={{ fontSize: 11 }}>→ {a.dst}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ flex: 1, overflow: "auto", padding: 20 }}>
+          {sel && <AlertDetail alert={sel} />}
+        </div>
+      </div>
+    </>
+  );
+};
+
+const AlertDetail = ({ alert: a }: { alert: DashboardData["alerts"][number] }) => (
+  <div className="col" style={{ gap: 14 }}>
+    <div className="row" style={{ gap: 8, alignItems: "flex-start" }}>
+      <div style={{ width: 36, height: 36, borderRadius: 8, background: "var(--danger-bg)", border: "1px solid var(--danger-border)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Icon name="siren" size={18} />
+      </div>
+      <div className="grow">
+        <div className="row" style={{ gap: 6, marginBottom: 4 }}>
+          <Sev level={a.sev} /><Badge variant="info">{a.cat}</Badge>
+          <span className="mono muted" style={{ fontSize: 11 }}>{a.id}</span>
+        </div>
+        <h2 style={{ fontSize: 18, fontWeight: 500, letterSpacing: "-0.01em" }}>{a.title}</h2>
+        <div className="muted" style={{ fontSize: 12, marginTop: 3 }}>{a.asset} · {a.ts} · → <span className="mono">{a.dst}</span></div>
+      </div>
+      <div className="row" style={{ gap: 6 }}>
+        <button type="button" className="btn"><Icon name="user-plus" size={12} /> アサイン</button>
+        <button type="button" className="btn accent"><Icon name="play" size={12} /> 調査</button>
+      </div>
+    </div>
+
+    <div className="grid" style={{ gridTemplateColumns: "1fr 1fr 1fr 1fr", gap: 10 }}>
+      {[
+        ["MITRE ATT&CK", "T1059.007", "JavaScript"],
+        ["信頼度", "94%", "高"],
+        ["CVSS", "9.1", "Critical"],
+        ["最初の検出", "09:12:44", "38秒前"],
+      ].map(([l, v, s]) => (
+        <div key={l} className="card" style={{ padding: 12, display: "flex", flexDirection: "column", gap: 2, minHeight: 74 }}>
+          <div className="metric-label" style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{l}</div>
+          <div style={{ fontSize: 17, fontWeight: 400, letterSpacing: "-0.01em", lineHeight: 1.2, marginTop: "auto" }}>{v}</div>
+          <div className="muted" style={{ fontSize: 11, lineHeight: 1.3 }}>{s}</div>
+        </div>
+      ))}
+    </div>
+
+    <div className="card">
+      <div className="card-hd"><h3>証跡 (Evidence)</h3><span className="hd-meta">RAW EVENT</span></div>
+      <pre style={{ padding: 14, fontFamily: "var(--font-mono)", fontSize: 11, lineHeight: 1.6, color: "var(--muted-foreground)", overflowX: "auto" }}>
+{`{
+  "alertId": "${a.id}",
+  "timestamp": "2026-04-23T09:12:44.238Z",
+  "severity": "${a.sev}",
+  "category": "${a.cat}",
+  "asset": { "id": "BR-0006", "user": "wong.chenxi@sh.com.sg", "browser": "Brave 1.72.123" },
+  "detection": {
+    "rule": "BDR-V8-TYPE-CONFUSION",
+    "cve": "CVE-2026-3091",
+    "technique": "T1059.007",
+    "confidence": 0.94
+  },
+  "action": "isolate_session",
+  "destination": "${a.dst}",
+  "dataClasses": ["pii", "financial"],
+  "enrichment": {
+    "threatFeed": "mandiant-apt41-indicators",
+    "firstSeenGlobal": "2026-04-12T14:22:00Z"
+  }
+}`}
+      </pre>
+    </div>
+
+    <div className="grid" style={{ gridTemplateColumns: "1fr 1fr", gap: 14 }}>
+      <div className="card">
+        <div className="card-hd"><h3>キルチェーン</h3></div>
+        <div className="card-body">
+          <div className="col" style={{ gap: 8 }}>
+            {[
+              { stage: "Recon", status: "done", ts: "09:10:21", detail: "サイト指紋採取 (WebGL)" },
+              { stage: "Delivery", status: "done", ts: "09:11:42", detail: "悪質スクリプト配信" },
+              { stage: "Exploit", status: "active", ts: "09:12:44", detail: "V8型混乱 (CVE-2026-3091)" },
+              { stage: "C2", status: "pending", ts: "—", detail: "未確認" },
+              { stage: "Exfil", status: "pending", ts: "—", detail: "未確認" },
+            ].map(s => (
+              <div key={s.stage} className="row" style={{ gap: 10 }}>
+                <div style={{
+                  width: 8, height: 8, borderRadius: 50,
+                  background: s.status === "active" ? "var(--danger)" : s.status === "done" ? "var(--muted-foreground)" : "var(--border)",
+                }} />
+                <div style={{ minWidth: 80, fontSize: 12, fontWeight: s.status === "active" ? 500 : 400 }}>{s.stage}</div>
+                <div className="muted" style={{ fontSize: 11, flex: 1 }}>{s.detail}</div>
+                <span className="mono muted" style={{ fontSize: 10 }}>{s.ts}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-hd"><h3>対応アクション</h3></div>
+        <div className="card-body" style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <button type="button" className="btn danger" style={{ justifyContent: "flex-start" }}><Icon name="shield-off" size={12} /> ブラウザセッションを隔離</button>
+          <button type="button" className="btn" style={{ justifyContent: "flex-start" }}><Icon name="key-round" size={12} /> 全セッショントークンを失効</button>
+          <button type="button" className="btn" style={{ justifyContent: "flex-start" }}><Icon name="ban" size={12} /> {a.dst} を組織全体でブロック</button>
+          <button type="button" className="btn" style={{ justifyContent: "flex-start" }}><Icon name="user-x" size={12} /> ユーザーのSSOを強制ログアウト</button>
+          <button type="button" className="btn" style={{ justifyContent: "flex-start" }}><Icon name="send" size={12} /> XSOARにエスカレーション</button>
+          <div style={{ padding: "8px 10px", background: "var(--info-bg)", border: "1px solid var(--info-border)", borderRadius: 6, fontSize: 11, color: "var(--info-foreground)", marginTop: 4 }}>
+            <Icon name="info" size={10} /> 自動プレイブック「V8-RCE-Contain」を実行可能
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export const InvestigationPage = () => {
+  const [t, setT] = useState(34);
+  const events: Array<{ ts: string; pos: number; sev: Severity; title: string; detail: string }> = [
+    { ts: "09:09:10", pos: 5, sev: "info", title: "ユーザーがbrowserを起動", detail: "Brave 1.72.123 · BR-0006" },
+    { ts: "09:10:21", pos: 14, sev: "info", title: "salesforce.comにログイン", detail: "SSO via Okta · OAuth grant" },
+    { ts: "09:10:58", pos: 22, sev: "medium", title: "WebGL指紋採取検出", detail: "unknown-cdn.io/fp.js" },
+    { ts: "09:11:42", pos: 28, sev: "high", title: "悪質スクリプト読込", detail: "unknown-cdn.io/sw.js · SHA: 4a8e...b2" },
+    { ts: "09:12:44", pos: 34, sev: "critical", title: "V8型混乱のエクスプロイト試行", detail: "CVE-2026-3091 · document.body構造破壊" },
+    { ts: "09:13:05", pos: 40, sev: "critical", title: "Cookie窃取: document.cookie", detail: "Salesforce + Notion sessionCookie" },
+    { ts: "09:13:28", pos: 46, sev: "critical", title: "外部送信: hxxps://unknown-cdn.io/c.gif", detail: "4.2KB · Base64エンコード" },
+    { ts: "09:14:02", pos: 55, sev: "high", title: "ダウンロード: accounts_q1.csv", detail: "218MB · salesforce.com" },
+    { ts: "09:14:38", pos: 62, sev: "info", title: "Plenoが自動隔離を実行", detail: "セッション失効 · サイトブロック" },
+  ];
+
+  return (
+    <>
+      <PageHeader
+        title="フォレンジック調査"
+        kicker="SESSION REPLAY · CASE SH-2026-0423-001"
+        sub="Mandiantスタイルのタイムライン再生。ブラウザ上で発生した全イベントを再構築し、証跡とキルチェーンを照合。"
+        actions={<>
+          <button type="button" className="btn"><Icon name="download" size={12} /> IOCエクスポート</button>
+          <button type="button" className="btn"><Icon name="file-text" size={12} /> PDFレポート</button>
+          <button type="button" className="btn accent"><Icon name="git-branch" size={12} /> グラフに表示</button>
+        </>}
+      />
+      <div className="page-body">
+        <div className="card" style={{ marginBottom: 16 }}>
+          <div className="card-hd">
+            <h3>ケース: wong.chenxi@sh.com.sg · BR-0006 (Brave)</h3>
+            <span className="row" style={{ gap: 8 }}>
+              <Badge variant="danger">active</Badge>
+              <Badge variant="accent">割当: J. Park (Tier2)</Badge>
+              <span className="mono muted" style={{ fontSize: 11 }}>2026/4/23 09:09 - 09:15 (6分)</span>
+            </span>
+          </div>
+          <div style={{ padding: 16 }}>
+            <ReplayTimeline events={events} t={t} onT={setT} />
+          </div>
+        </div>
+
+        <div className="grid" style={{ gridTemplateColumns: "1.2fr 1fr", gap: 14 }}>
+          <div className="card">
+            <div className="card-hd"><h3>イベントログ</h3><span className="hd-meta">{events.length} EVENTS</span></div>
+            <div>
+              {events.map((e, i) => {
+                const active = Math.abs(e.pos - t) < 3;
+                return (
+                  <div key={i} className="list-row" onClick={() => setT(e.pos)}
+                    style={{
+                      gridTemplateColumns: "60px 70px 1fr", padding: "10px 14px", fontSize: 12,
+                      background: active ? "var(--accent-bg)" : undefined,
+                      borderBottom: i === events.length - 1 ? "none" : undefined,
+                    }}>
+                    <span className="mono muted" style={{ fontSize: 11 }}>{e.ts}</span>
+                    <Sev level={e.sev} />
+                    <div>
+                      <div style={{ fontWeight: active ? 500 : 400 }}>{e.title}</div>
+                      <div className="muted" style={{ fontSize: 11, marginTop: 2 }}>{e.detail}</div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="col" style={{ gap: 14 }}>
+            <div className="card">
+              <div className="card-hd"><h3>IOC (indicators of compromise)</h3></div>
+              <div className="card-body" style={{ fontSize: 12, fontFamily: "var(--font-mono)", lineHeight: 1.8 }}>
+                <div className="row" style={{ gap: 6 }}><Badge variant="danger">DOMAIN</Badge><span>unknown-cdn.io</span></div>
+                <div className="row" style={{ gap: 6 }}><Badge variant="danger">URL</Badge><span>hxxps://unknown-cdn.io/sw.js</span></div>
+                <div className="row" style={{ gap: 6 }}><Badge variant="danger">SHA256</Badge><span>4a8e...b2cf</span></div>
+                <div className="row" style={{ gap: 6 }}><Badge variant="warning">CVE</Badge><span>CVE-2026-3091</span></div>
+                <div className="row" style={{ gap: 6 }}><Badge variant="warning">TTP</Badge><span>T1059.007 · T1539</span></div>
+              </div>
+            </div>
+
+            <div className="card">
+              <div className="card-hd"><h3>関連アセット</h3></div>
+              <div className="card-body" style={{ display: "flex", flexDirection: "column", gap: 6, fontSize: 12 }}>
+                {["wong.chenxi@sh.com.sg (user)", "BR-0006 (browser)", "salesforce.com (SaaS)", "notion.so (SaaS)", "unknown-cdn.io (threat)"].map(x => (
+                  <div key={x} className="row" style={{ justifyContent: "space-between" }}>
+                    <span>{x}</span>
+                    <Icon name="external-link" size={11} color="muted" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+const ReplayTimeline = ({
+  events, t, onT,
+}: {
+  events: Array<{ ts: string; pos: number; sev: Severity; title: string }>;
+  t: number;
+  onT: (n: number) => void;
+}) => (
+  <div>
+    <div style={{ position: "relative", height: 54, marginBottom: 10 }}>
+      <div style={{ position: "absolute", inset: "20px 0 20px 0", background: "var(--tertiary)", borderRadius: 3, border: "1px solid var(--border)" }} />
+      {events.map((e, i) => {
+        const color = e.sev === "critical" ? "var(--danger)" : e.sev === "high" ? "var(--warning)" : e.sev === "medium" ? "var(--info)" : "var(--muted-foreground)";
+        return (
+          <div key={i} onClick={() => onT(e.pos)} title={`${e.ts} ${e.title}`}
+            style={{ position: "absolute", left: `calc(${e.pos}% - 4px)`, top: 14, width: 8, height: 26, background: color, borderRadius: 2, cursor: "pointer", border: "1px solid var(--background)" }} />
+        );
+      })}
+      <div style={{ position: "absolute", left: `calc(${t}% - 1px)`, top: 4, bottom: 4, width: 2, background: "var(--foreground)" }}>
+        <div style={{ position: "absolute", top: -6, left: -5, width: 12, height: 12, background: "var(--foreground)", borderRadius: 2, transform: "rotate(45deg)" }} />
+      </div>
+      <div style={{ position: "absolute", left: 0, right: 0, bottom: 0, display: "flex", justifyContent: "space-between", fontSize: 10, color: "var(--muted-foreground)", fontFamily: "var(--font-mono)" }}>
+        <span>09:09:10</span><span>09:11:00</span><span>09:13:00</span><span>09:15:00</span>
+      </div>
+    </div>
+    <div className="row" style={{ gap: 8 }}>
+      <button type="button" className="btn sm"><Icon name="skip-back" size={11} /></button>
+      <button type="button" className="btn sm primary"><Icon name="play" size={11} /></button>
+      <button type="button" className="btn sm"><Icon name="skip-forward" size={11} /></button>
+      <input type="range" min={0} max={100} value={t} onChange={e => onT(+e.target.value)} style={{ flex: 1 }} />
+      <span className="mono" style={{ fontSize: 12 }}>09:{String(9 + Math.floor(t / 20)).padStart(2, "0")}:{String(Math.floor((t % 20) * 3)).padStart(2, "0")}</span>
+    </div>
+  </div>
+);
+
+export const ExfilPage = ({ data }: { data: DashboardData }) => (
+  <>
+    <PageHeader
+      title="データ漏洩モニター"
+      kicker="EXFIL MONITOR"
+      sub="貼り付け、アップロード、フォーム送信、ダウンロードの全チャネルを監視。AIプロンプトへの機密投入を含む。"
+      actions={<>
+        <button type="button" className="btn"><Icon name="filter" size={12} /> フィルタ</button>
+        <button type="button" className="btn accent"><Icon name="shield" size={12} /> DLPルール編集</button>
+      </>}
+    />
+    <div className="page-body">
+      <div className="grid" style={{ gridTemplateColumns: "repeat(4, 1fr)", marginBottom: 16 }}>
+        <Metric label="24h 漏洩イベント" value={64} delta={+8} spark={[4, 6, 5, 8, 7, 9, 11, 12]} />
+        <Metric label="ブロック済" value={42} delta={+14} spark={[2, 3, 4, 5, 6, 7, 8, 9]} />
+        <Metric label="AI宛 (chatgpt/claude)" value={284} delta={+52} sub="前日比" spark={[20, 30, 45, 60, 88, 120, 180, 284]} />
+        <Metric label="保護データ量" value="2.8" unit="GB" delta={+12} spark={[1, 2, 2, 3, 3, 4, 5, 6]} />
+      </div>
+
+      <div className="card" style={{ marginBottom: 16 }}>
+        <div className="card-hd"><h3>漏洩チャネル別分布 (24h)</h3><span className="hd-meta">LAST 24H</span></div>
+        <div className="card-body" style={{ display: "flex", gap: 24, alignItems: "flex-end" }}>
+          {[
+            { ch: "AIプロンプト", n: 284, c: "var(--danger)" },
+            { ch: "貼り付け", n: 112, c: "var(--warning)" },
+            { ch: "ダウンロード", n: 68, c: "var(--warning)" },
+            { ch: "フォーム送信", n: 42, c: "var(--info)" },
+            { ch: "アップロード", n: 34, c: "var(--info)" },
+            { ch: "印刷", n: 18, c: "var(--muted-foreground)" },
+            { ch: "クリップボード", n: 14, c: "var(--muted-foreground)" },
+          ].map(({ ch, n, c }) => (
+            <div key={ch} style={{ flex: 1, textAlign: "center" }}>
+              <div className="mono" style={{ fontSize: 18, fontWeight: 400, letterSpacing: "-0.01em" }}>{n}</div>
+              <div style={{ height: 80, background: "var(--tertiary)", borderRadius: 4, position: "relative", overflow: "hidden", marginTop: 6, border: "1px solid var(--border)" }}>
+                <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, background: c, height: `${Math.min(100, (n / 284) * 100)}%`, borderRadius: "0 0 3px 3px" }} />
+              </div>
+              <div className="muted" style={{ fontSize: 10, marginTop: 6, textTransform: "uppercase", letterSpacing: "0.06em" }}>{ch}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="list">
+        <div className="list-hd" style={{ gridTemplateColumns: "80px 100px 120px 140px 100px 100px 1fr 100px" }}>
+          <span>時刻</span><span>ユーザー</span><span>チャネル</span><span>送信先</span><span>種別</span><span>サイズ</span><span>データクラス</span><span>アクション</span>
+        </div>
+        {data.exfilEvents.map((e, i) => (
+          <div key={i} className="list-row" style={{ gridTemplateColumns: "80px 100px 120px 140px 100px 100px 1fr 100px" }}>
+            <span className="mono" style={{ fontSize: 11 }}>{e.ts}</span>
+            <span>{e.actor}</span>
+            <Badge variant={e.channel === "AIプロンプト" ? "danger" : "warning"}>{e.channel}</Badge>
+            <span className="mono" style={{ fontSize: 11 }}>{e.dst}</span>
+            <span className="muted" style={{ fontSize: 12 }}>{e.kind}</span>
+            <span className="mono tabular">{e.bytes}</span>
+            <span className="row" style={{ gap: 4 }}>{e.classes.map(c => <Badge key={c} variant="warning">{c}</Badge>)}</span>
+            <Badge variant={e.action === "ブロック" ? "danger" : "info"}>{e.action}</Badge>
+          </div>
+        ))}
+      </div>
+    </div>
+  </>
+);
+
+export const IdentityPage = ({ data }: { data: DashboardData }) => (
+  <>
+    <PageHeader
+      title="アイデンティティ & セッション"
+      kicker="IDENTITY RISK"
+      sub="OAuthスコープ昇格、不可能な移動、MFAバイパス、トークン抜き出しを監視。IdPとの双方向同期。"
+      actions={<>
+        <button type="button" className="btn"><Icon name="key" size={12} /> 全セッション表示</button>
+        <button type="button" className="btn accent"><Icon name="user-x" size={12} /> 強制ログアウト</button>
+      </>}
+    />
+    <div className="page-body">
+      <div className="grid" style={{ gridTemplateColumns: "repeat(4, 1fr)", marginBottom: 16 }}>
+        <Metric label="アクティブセッション" value={41268} delta={-2} sub="4リージョン" />
+        <Metric label="高リスクユーザー" value={184} delta={+8} sub="スコア >70" />
+        <Metric label="OAuth昇格 (24h)" value={12} delta={+4} sub="要確認" />
+        <Metric label="不可能な移動" value={7} delta={+2} sub="地理異常" />
+      </div>
+
+      <div className="grid" style={{ gridTemplateColumns: "1.5fr 1fr", gap: 14 }}>
+        <div className="card">
+          <div className="card-hd"><h3>リスクイベント</h3><span className="hd-meta">ACTIVE CASES</span></div>
+          <div className="list-hd" style={{ gridTemplateColumns: "minmax(0, 1.6fr) 80px minmax(0, 1.2fr) minmax(0, 0.8fr) 70px minmax(0, 1.4fr)", borderRadius: 0 }}>
+            <span>ユーザー</span><span>重要度</span><span>イベント</span><span>アプリ</span><span>時刻</span><span>詳細</span>
+          </div>
+          {data.identity.map((r, i) => {
+            const [local, domain] = r.user.split("@");
+            return (
+              <div key={i} className="list-row" style={{ gridTemplateColumns: "minmax(0, 1.6fr) 80px minmax(0, 1.2fr) minmax(0, 0.8fr) 70px minmax(0, 1.4fr)" }}>
+                <span className="row" style={{ gap: 8, minWidth: 0 }}>
+                  <span style={{ flexShrink: 0, width: 24, height: 24, borderRadius: 5, background: "var(--accent)", color: "white", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 10, fontWeight: 500 }}>
+                    {local.charAt(0).toUpperCase()}
+                  </span>
+                  <span className="col" style={{ gap: 0, minWidth: 0 }}>
+                    <span className="ellip" style={{ fontSize: 12, fontWeight: 500 }}>{local}</span>
+                    <span className="ellip muted mono" style={{ fontSize: 10 }}>@{domain}</span>
+                  </span>
+                </span>
+                <Sev level={r.risk} />
+                <span className="ellip" style={{ fontWeight: 500, fontSize: 12 }} title={r.event}>{r.event}</span>
+                <span className="ellip muted" style={{ fontSize: 12 }}>{r.app}</span>
+                <span className="mono" style={{ fontSize: 11 }}>{r.ts}</span>
+                <span className="ellip muted mono" style={{ fontSize: 11 }} title={r.detail}>{r.detail}</span>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="col" style={{ gap: 14 }}>
+          <div className="card">
+            <div className="card-hd"><h3>OAuth付与</h3><span className="hd-meta">HIGH SCOPE</span></div>
+            <div className="card-body" style={{ fontSize: 12, display: "flex", flexDirection: "column", gap: 10 }}>
+              {[
+                ["Notion", "workspace.admin, users:read", 14, "high"] as const,
+                ["Slack", "channels:history, files:read", 8, "medium"] as const,
+                ["GitHub", "repo, admin:org", 4, "high"] as const,
+                ["Google Drive", "drive.file, drive.metadata.readonly", 42, "medium"] as const,
+              ].map(([app, scope, n, sev]) => (
+                <div key={app} className="col" style={{ gap: 3 }}>
+                  <div className="row" style={{ justifyContent: "space-between" }}>
+                    <span style={{ fontWeight: 500 }}>{app}</span>
+                    <span className="row" style={{ gap: 6 }}><Badge variant={sev === "high" ? "danger" : "warning"}>{sev}</Badge><span className="mono tabular">{n}</span></span>
+                  </div>
+                  <div className="muted mono" style={{ fontSize: 10 }}>{scope}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card-hd"><h3>MFA姿勢</h3></div>
+            <div className="card-body">
+              <div className="row" style={{ justifyContent: "space-between", marginBottom: 10 }}>
+                <span className="metric-val tabular" style={{ fontSize: 32 }}>94.2%</span>
+                <div style={{ textAlign: "right" }}>
+                  <div className="metric-delta down">▼ 0.4%</div>
+                  <div className="muted" style={{ fontSize: 11 }}>48,288 / 51,204</div>
+                </div>
+              </div>
+              <RiskBarScore value={94.2} color="var(--success)" />
+              <div className="muted" style={{ fontSize: 11, marginTop: 8 }}>2,916名がMFA未設定 · <span className="pleno-link">強制登録を実行</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+);

--- a/app/audit-enterprise/src/pages/Governance.tsx
+++ b/app/audit-enterprise/src/pages/Governance.tsx
@@ -1,0 +1,176 @@
+import type { DashboardData } from "../data";
+import { Badge, Dot, Icon, PageHeader, RiskBarScore } from "../components/ui";
+
+export const CompliancePage = ({ data }: { data: DashboardData }) => (
+  <>
+    <PageHeader
+      title="コンプライアンス"
+      kicker="EVIDENCE & FRAMEWORKS"
+      sub="ZTBS/BDR/CASB制御をフレームワークにマッピング。監査証跡を自動収集しエビデンスを常時整合。"
+      actions={<>
+        <button type="button" className="btn"><Icon name="download" size={12} /> 監査パッケージ</button>
+        <button type="button" className="btn accent"><Icon name="file-check" size={12} /> エビデンス同期</button>
+      </>}
+    />
+    <div className="page-body">
+      <div className="grid" style={{ gridTemplateColumns: "repeat(3, 1fr)", gap: 14, marginBottom: 16 }}>
+        {data.compliance.map(c => {
+          const sev: "success" | "info" | "warning" = c.score >= 90 ? "success" : c.score >= 80 ? "info" : "warning";
+          return (
+            <div key={c.framework} className="card">
+              <div className="card-hd">
+                <h3>{c.framework}</h3>
+                <Badge variant={sev}>{c.score}%</Badge>
+              </div>
+              <div className="card-body" style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+                <RiskBarScore value={c.score} color={`var(--${sev})`} />
+                <div className="grid" style={{ gridTemplateColumns: "repeat(4, 1fr)", gap: 6, fontSize: 11 }}>
+                  <div className="col" style={{ gap: 2 }}>
+                    <span className="metric-label">制御</span>
+                    <span className="mono tabular" style={{ fontSize: 14 }}>{c.controls}</span>
+                  </div>
+                  <div className="col" style={{ gap: 2 }}>
+                    <span className="metric-label" style={{ color: "var(--success-foreground)" }}>合格</span>
+                    <span className="mono tabular" style={{ fontSize: 14 }}>{c.passing}</span>
+                  </div>
+                  <div className="col" style={{ gap: 2 }}>
+                    <span className="metric-label" style={{ color: "var(--warning-foreground)" }}>部分</span>
+                    <span className="mono tabular" style={{ fontSize: 14 }}>{c.partial}</span>
+                  </div>
+                  <div className="col" style={{ gap: 2 }}>
+                    <span className="metric-label" style={{ color: "var(--danger-foreground)" }}>不合格</span>
+                    <span className="mono tabular" style={{ fontSize: 14 }}>{c.failing}</span>
+                  </div>
+                </div>
+                <div className="row" style={{ justifyContent: "space-between", fontSize: 11, color: "var(--muted-foreground)", borderTop: "1px solid var(--border-light)", paddingTop: 8 }}>
+                  <span>次回監査</span>
+                  <span className="mono">{c.audit}</span>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="card">
+        <div className="card-hd"><h3>制御マッピング (SOC 2 Type II · 抜粋)</h3><span className="hd-meta">AUTO-EVIDENCE</span></div>
+        <div className="list-hd" style={{ gridTemplateColumns: "100px 1.5fr 1fr 90px 120px 90px", borderRadius: 0 }}>
+          <span>制御ID</span><span>要件</span><span>Pleno機能</span><span>状態</span><span>最終検証</span><span>エビデンス</span>
+        </div>
+        {([
+          ["CC6.1", "論理アクセス制御", "アイデンティティ + MFA強制", "success", "2026/4/22", 14],
+          ["CC6.6", "エンドポイント保護", "BDRエージェント + EDR連携", "success", "2026/4/22", 82],
+          ["CC6.7", "データ転送中の保護", "DLPルール + ブラウザ隔離", "success", "2026/4/23", 38],
+          ["CC7.2", "異常検出", "BDR + 行動分析", "warning", "2026/4/21", 24],
+          ["CC7.3", "インシデント対応", "XSOAR連携 + 自動隔離", "success", "2026/4/23", 12],
+        ] as const).map((r, i) => (
+          <div key={i} className="list-row" style={{ gridTemplateColumns: "100px 1.5fr 1fr 90px 120px 90px" }}>
+            <span className="mono">{r[0]}</span>
+            <span style={{ fontWeight: 500, fontSize: 12 }}>{r[1]}</span>
+            <span className="muted" style={{ fontSize: 12 }}>{r[2]}</span>
+            <Badge variant={r[3] as "success" | "warning"}>{r[3] === "success" ? "合格" : "要対応"}</Badge>
+            <span className="mono muted" style={{ fontSize: 11 }}>{r[4]}</span>
+            <span className="row" style={{ gap: 4 }}><Icon name="file-text" size={11} color="muted" /><span className="mono tabular">{r[5]}</span></span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </>
+);
+
+export const IntegrationsPage = ({ data }: { data: DashboardData }) => (
+  <>
+    <PageHeader
+      title="統合 & コネクタ"
+      kicker="INTEGRATIONS"
+      sub="SIEM、SOAR、EDR、IdP、MDM、通知チャネルへの双方向連携。イベントはローカル処理後、メタデータのみ同期。"
+      actions={<>
+        <button type="button" className="btn"><Icon name="book" size={12} /> APIドキュメント</button>
+        <button type="button" className="btn accent"><Icon name="plug" size={12} /> 新規接続</button>
+      </>}
+    />
+    <div className="page-body">
+      <div className="grid" style={{ gridTemplateColumns: "repeat(3, 1fr)", gap: 14 }}>
+        {data.integrations.map(it => (
+          <div key={it.name} className="card">
+            <div style={{ padding: 14, display: "flex", gap: 12, alignItems: "flex-start" }}>
+              <div style={{ width: 36, height: 36, borderRadius: 8, background: "var(--tertiary)", border: "1px solid var(--border)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                <Icon name={intIcon(it.icon)} size={18} />
+              </div>
+              <div className="grow">
+                <div className="row" style={{ justifyContent: "space-between" }}>
+                  <span style={{ fontWeight: 500 }}>{it.name}</span>
+                  <Badge variant={it.status === "接続" ? "success" : "default"}>
+                    {it.status === "接続" && <Dot color="var(--success)" size={5} />}
+                    {it.status}
+                  </Badge>
+                </div>
+                <div className="muted" style={{ fontSize: 11, marginTop: 2 }}>{it.cat}</div>
+                <div className="row" style={{ justifyContent: "space-between", marginTop: 10, fontSize: 11 }}>
+                  <span className="muted">イベント/日</span>
+                  <span className="mono tabular">{it.events}</span>
+                </div>
+                <div className="row" style={{ justifyContent: "space-between", marginTop: 2, fontSize: 11 }}>
+                  <span className="muted">接続日</span>
+                  <span className="mono">{it.since}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+
+        <div className="card" style={{ padding: 14, display: "flex", alignItems: "center", justifyContent: "center", minHeight: 130, border: "1px dashed var(--border)", background: "transparent", cursor: "pointer" }}>
+          <div className="col" style={{ alignItems: "center", gap: 6 }}>
+            <Icon name="plus" size={20} color="muted" />
+            <span className="muted" style={{ fontSize: 12 }}>統合を追加</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="card" style={{ marginTop: 16 }}>
+        <div className="card-hd"><h3>データフロー</h3><span className="hd-meta">LOCAL-FIRST · METADATA ONLY</span></div>
+        <div className="card-body">
+          <div className="row" style={{ justifyContent: "space-between", gap: 20, padding: "10px 0" }}>
+            <div className="col" style={{ alignItems: "center", gap: 6, flex: 1 }}>
+              <div style={{ width: 52, height: 52, borderRadius: 10, background: "var(--accent-bg)", border: "1px solid var(--accent-border)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                <Icon name="monitor" size={22} />
+              </div>
+              <div style={{ fontSize: 12, fontWeight: 500 }}>ブラウザ (拡張機能)</div>
+              <div className="muted" style={{ fontSize: 11 }}>ローカル解析 · 暗号化</div>
+            </div>
+            <Icon name="arrow-right" size={16} color="muted" />
+            <div className="col" style={{ alignItems: "center", gap: 6, flex: 1 }}>
+              <div style={{ width: 52, height: 52, borderRadius: 10, background: "var(--tertiary)", border: "1px solid var(--border)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                <Icon name="server" size={22} />
+              </div>
+              <div style={{ fontSize: 12, fontWeight: 500 }}>Plenoコントロールプレーン</div>
+              <div className="muted" style={{ fontSize: 11 }}>メタデータのみ · 生データ非保存</div>
+            </div>
+            <Icon name="arrow-right" size={16} color="muted" />
+            <div className="col" style={{ alignItems: "center", gap: 6, flex: 1 }}>
+              <div style={{ width: 52, height: 52, borderRadius: 10, background: "var(--tertiary)", border: "1px solid var(--border)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                <Icon name="activity" size={22} />
+              </div>
+              <div style={{ fontSize: 12, fontWeight: 500 }}>SIEM / SOAR / EDR</div>
+              <div className="muted" style={{ fontSize: 11 }}>双方向連携 · エンリッチメント</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+function intIcon(pascal: string): string {
+  const map: Record<string, string> = {
+    Activity: "activity",
+    Shield: "shield",
+    Key: "key",
+    Workflow: "workflow",
+    Smartphone: "smartphone",
+    MessageSquare: "message-square",
+    Bell: "bell",
+    Settings: "settings",
+  };
+  return map[pascal] ?? "plug";
+}

--- a/app/audit-enterprise/src/pages/Graph.tsx
+++ b/app/audit-enterprise/src/pages/Graph.tsx
@@ -1,0 +1,322 @@
+import { useMemo, useState } from "react";
+import type { Severity } from "../data";
+import { Badge, Dot, Icon, PageHeader, Sev } from "../components/ui";
+
+type NodeType = "user" | "browser" | "app" | "threat" | "data";
+
+interface GraphNode {
+  id: string;
+  type: NodeType;
+  label: string;
+  risk: Severity;
+  meta: string;
+}
+
+type GraphEdge = readonly [string, string, string];
+
+const GRAPH: { nodes: GraphNode[]; edges: GraphEdge[] } = {
+  nodes: [
+    { id: "u:takahashi", type: "user", label: "takahashi.yui", risk: "high", meta: "法務部" },
+    { id: "u:wong", type: "user", label: "wong.chenxi", risk: "critical", meta: "エンジニアリング" },
+    { id: "u:kim", type: "user", label: "kim.jihoon", risk: "medium", meta: "財務部" },
+    { id: "u:schmidt", type: "user", label: "mara.schmidt", risk: "high", meta: "開発" },
+    { id: "b:0001", type: "browser", label: "takahashi-mbp", risk: "high", meta: "Chrome 131" },
+    { id: "b:0006", type: "browser", label: "sin-eng-tw", risk: "critical", meta: "Brave 1.72" },
+    { id: "b:0002", type: "browser", label: "SH-DESK-4421", risk: "medium", meta: "Edge 132" },
+    { id: "b:0003", type: "browser", label: "schmidt-dev", risk: "high", meta: "Chrome 131" },
+    { id: "a:chatgpt", type: "app", label: "ChatGPT", risk: "critical", meta: "AI" },
+    { id: "a:claude", type: "app", label: "Claude", risk: "critical", meta: "AI" },
+    { id: "a:notion", type: "app", label: "Notion", risk: "high", meta: "Docs" },
+    { id: "a:salesforce", type: "app", label: "Salesforce", risk: "medium", meta: "CRM" },
+    { id: "a:github", type: "app", label: "GitHub", risk: "medium", meta: "Code" },
+    { id: "t:cve", type: "threat", label: "CVE-2026-3091", risk: "critical", meta: "V8 RCE" },
+    { id: "t:ext", type: "threat", label: "SuperTabs Pro", risk: "critical", meta: "悪質拡張" },
+    { id: "t:cdn", type: "threat", label: "unknown-cdn.io", risk: "critical", meta: "C2疑い" },
+    { id: "d:pii", type: "data", label: "PII", risk: "high", meta: "顧客情報" },
+    { id: "d:fin", type: "data", label: "財務", risk: "critical", meta: "売上" },
+    { id: "d:src", type: "data", label: "ソース", risk: "high", meta: "リポジトリ" },
+  ],
+  edges: [
+    ["u:takahashi", "b:0001", "使用"],
+    ["u:wong", "b:0006", "使用"],
+    ["u:kim", "b:0002", "使用"],
+    ["u:schmidt", "b:0003", "使用"],
+    ["b:0001", "a:chatgpt", "ログイン"],
+    ["b:0001", "a:notion", "ログイン"],
+    ["b:0006", "a:salesforce", "ログイン"],
+    ["b:0006", "a:github", "ログイン"],
+    ["b:0002", "a:claude", "ログイン"],
+    ["b:0003", "a:chatgpt", "ログイン"],
+    ["b:0003", "a:github", "ログイン"],
+    ["b:0001", "t:ext", "インストール"],
+    ["b:0006", "t:cve", "影響"],
+    ["b:0006", "t:cdn", "通信"],
+    ["b:0003", "t:ext", "インストール"],
+    ["a:chatgpt", "d:pii", "送信"],
+    ["a:chatgpt", "d:fin", "送信"],
+    ["a:claude", "d:pii", "送信"],
+    ["a:salesforce", "d:pii", "保存"],
+    ["a:github", "d:src", "保存"],
+    ["a:notion", "d:pii", "保存"],
+  ],
+};
+
+type Shape = "circle" | "square" | "hex" | "diamond";
+const TYPE_META: Record<NodeType, { shape: Shape; icon: string; size: number }> = {
+  user: { shape: "circle", icon: "user-check", size: 18 },
+  browser: { shape: "square", icon: "monitor", size: 20 },
+  app: { shape: "hex", icon: "layers", size: 22 },
+  threat: { shape: "circle", icon: "alert-triangle", size: 22 },
+  data: { shape: "diamond", icon: "database", size: 20 },
+};
+
+const RISK_COLOR: Record<Severity, string> = {
+  critical: "var(--danger)",
+  high: "var(--warning)",
+  medium: "var(--info)",
+  low: "var(--success)",
+  info: "var(--info)",
+  safe: "var(--success)",
+};
+
+function layout(nodes: GraphNode[], w: number, h: number) {
+  const cols: NodeType[] = ["user", "browser", "app", "threat", "data"];
+  const grouped = cols.map(t => nodes.filter(n => n.type === t));
+  const colW = w / cols.length;
+  const out: Record<string, { x: number; y: number }> = {};
+  grouped.forEach((group, ci) => {
+    const cx = colW * ci + colW / 2;
+    group.forEach((n, ri) => {
+      const spacing = h / (group.length + 1);
+      out[n.id] = { x: cx, y: spacing * (ri + 1) };
+    });
+  });
+  return out;
+}
+
+function hexPoints(r: number) {
+  const pts: string[] = [];
+  for (let i = 0; i < 6; i++) {
+    const a = (Math.PI / 3) * i + Math.PI / 6;
+    pts.push(`${(r * Math.cos(a)).toFixed(1)},${(r * Math.sin(a)).toFixed(1)}`);
+  }
+  return pts.join(" ");
+}
+
+export const GraphPage = () => {
+  const [selected, setSelected] = useState("b:0006");
+  const [filter, setFilter] = useState<"all" | NodeType>("all");
+  const [showLabels, setShowLabels] = useState(true);
+  const w = 960, h = 520;
+  const pos = useMemo(() => layout(GRAPH.nodes, w, h), []);
+
+  const neighbors = useMemo(() => {
+    const ns = new Set<string>([selected]);
+    const es = new Set<number>();
+    GRAPH.edges.forEach(([s, t], i) => {
+      if (s === selected || t === selected) {
+        ns.add(s);
+        ns.add(t);
+        es.add(i);
+      }
+    });
+    GRAPH.edges.forEach(([s, t], i) => {
+      if (ns.has(s) || ns.has(t)) es.add(i);
+    });
+    return { ns, es };
+  }, [selected]);
+
+  const filteredNodes = filter === "all" ? GRAPH.nodes : GRAPH.nodes.filter(n => n.type === filter || n.risk === "critical");
+  const selectedNode = GRAPH.nodes.find(n => n.id === selected);
+
+  return (
+    <>
+      <PageHeader
+        title="アセットグラフ"
+        kicker="ASSET GRAPH · HERO"
+        sub="ユーザー → ブラウザ → アプリ → データの関係を可視化。1ノードを選択して影響範囲 (blast radius) を2ホップまで確認できます。"
+        actions={
+          <>
+            <div className="seg">
+              <button type="button" className={filter === "all" ? "active" : ""} onClick={() => setFilter("all")}>全て</button>
+              <button type="button" className={filter === "user" ? "active" : ""} onClick={() => setFilter("user")}>ユーザー</button>
+              <button type="button" className={filter === "browser" ? "active" : ""} onClick={() => setFilter("browser")}>ブラウザ</button>
+              <button type="button" className={filter === "app" ? "active" : ""} onClick={() => setFilter("app")}>アプリ</button>
+              <button type="button" className={filter === "threat" ? "active" : ""} onClick={() => setFilter("threat")}>脅威</button>
+            </div>
+            <button type="button" className="btn" onClick={() => setShowLabels(v => !v)}>
+              <Icon name="tag" size={12} /> ラベル {showLabels ? "ON" : "OFF"}
+            </button>
+            <button type="button" className="btn accent"><Icon name="share-2" size={12} /> グラフ共有</button>
+          </>
+        }
+      />
+      <div className="page-body" style={{ padding: 0, display: "flex", minHeight: 0, flex: 1 }}>
+        <div style={{ flex: 1, position: "relative", background: "var(--background)", borderRight: "1px solid var(--border)", overflow: "hidden" }}>
+          <div style={{
+            position: "absolute", inset: "10px 0 auto 0", display: "grid", gridTemplateColumns: "repeat(5, 1fr)",
+            pointerEvents: "none", fontSize: 10, color: "var(--muted-foreground)", textTransform: "uppercase", letterSpacing: "0.1em",
+            fontFamily: "var(--font-mono)", zIndex: 2,
+          }}>
+            <div style={{ textAlign: "center" }}>identity</div>
+            <div style={{ textAlign: "center" }}>browser</div>
+            <div style={{ textAlign: "center" }}>saas / ai</div>
+            <div style={{ textAlign: "center" }}>threat</div>
+            <div style={{ textAlign: "center" }}>data</div>
+          </div>
+          <svg viewBox={`0 0 ${w} ${h}`} width="100%" height="100%" style={{ display: "block" }}>
+            {[1, 2, 3, 4].map(i => (
+              <line key={i} x1={(w / 5) * i} x2={(w / 5) * i} y1={30} y2={h - 10} stroke="var(--border-light)" strokeDasharray="3 3" />
+            ))}
+            {GRAPH.edges.map(([s, t], i) => {
+              const p1 = pos[s];
+              const p2 = pos[t];
+              if (!p1 || !p2) return null;
+              const inFilter = filteredNodes.find(n => n.id === s) && filteredNodes.find(n => n.id === t);
+              const isActive = neighbors.es.has(i);
+              if (!inFilter) return null;
+              const mx = (p1.x + p2.x) / 2;
+              const d = `M${p1.x},${p1.y} C${mx},${p1.y} ${mx},${p2.y} ${p2.x},${p2.y}`;
+              return (
+                <path key={i} d={d}
+                  stroke={isActive ? "var(--accent)" : "var(--border)"}
+                  strokeWidth={isActive ? 1.5 : 1}
+                  fill="none"
+                  opacity={isActive ? 0.9 : (selected ? 0.18 : 0.45)}
+                />
+              );
+            })}
+            {filteredNodes.map(n => {
+              const p = pos[n.id];
+              if (!p) return null;
+              const meta = TYPE_META[n.type];
+              const rc = RISK_COLOR[n.risk];
+              const isSelected = selected === n.id;
+              const isNeighbor = neighbors.ns.has(n.id) && !isSelected;
+              const dim = selected && !isSelected && !isNeighbor;
+              const r = meta.size / 2;
+              return (
+                <g key={n.id} transform={`translate(${p.x}, ${p.y})`}
+                  style={{ cursor: "pointer", opacity: dim ? 0.22 : 1, transition: "opacity 0.2s" }}
+                  onClick={() => setSelected(n.id)}
+                >
+                  {isSelected && <circle r={r + 8} fill="none" stroke="var(--accent)" strokeWidth="1.5" strokeDasharray="3 2" />}
+                  {meta.shape === "circle" && <circle r={r} fill="var(--background)" stroke={rc} strokeWidth="2" />}
+                  {meta.shape === "square" && <rect x={-r} y={-r} width={r * 2} height={r * 2} rx="3" fill="var(--background)" stroke={rc} strokeWidth="2" />}
+                  {meta.shape === "hex" && (
+                    <polygon points={hexPoints(r)} fill="var(--background)" stroke={rc} strokeWidth="2" />
+                  )}
+                  {meta.shape === "diamond" && (
+                    <polygon points={`0,${-r} ${r},0 0,${r} ${-r},0`} fill="var(--background)" stroke={rc} strokeWidth="2" />
+                  )}
+                  <foreignObject x={-8} y={-8} width={16} height={16} style={{ pointerEvents: "none" }}>
+                    <div style={{ width: 16, height: 16, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                      <Icon name={meta.icon} size={11} />
+                    </div>
+                  </foreignObject>
+                  {showLabels && (
+                    <text x={0} y={r + 12} textAnchor="middle" className="graph-node-label"
+                      style={{ fontSize: 10, fill: isSelected ? "var(--foreground)" : "var(--muted-foreground)", fontWeight: isSelected ? 500 : 400 }}>
+                      {n.label}
+                    </text>
+                  )}
+                  {n.risk === "critical" && (
+                    <circle cx={r - 2} cy={-r + 2} r="3" fill="var(--danger)" stroke="var(--background)" strokeWidth="1" />
+                  )}
+                </g>
+              );
+            })}
+          </svg>
+          <div style={{ position: "absolute", bottom: 14, left: 14, background: "var(--background)", border: "1px solid var(--border)", borderRadius: 8, padding: "8px 12px", fontSize: 11, display: "flex", gap: 14 }}>
+            <span className="row" style={{ gap: 5 }}><Dot color="var(--danger)" /> critical</span>
+            <span className="row" style={{ gap: 5 }}><Dot color="var(--warning)" /> high</span>
+            <span className="row" style={{ gap: 5 }}><Dot color="var(--info)" /> medium</span>
+            <span className="row" style={{ gap: 5 }}><Dot color="var(--success)" /> low</span>
+          </div>
+          <div style={{ position: "absolute", bottom: 14, right: 14, display: "flex", gap: 4 }}>
+            <button type="button" className="icon-btn" style={{ background: "var(--background)", border: "1px solid var(--border)" }}><Icon name="zoom-in" size={13} color="muted" /></button>
+            <button type="button" className="icon-btn" style={{ background: "var(--background)", border: "1px solid var(--border)" }}><Icon name="zoom-out" size={13} color="muted" /></button>
+            <button type="button" className="icon-btn" style={{ background: "var(--background)", border: "1px solid var(--border)" }}><Icon name="maximize" size={13} color="muted" /></button>
+          </div>
+        </div>
+
+        <div style={{ width: 320, overflow: "auto", padding: 18, display: "flex", flexDirection: "column", gap: 14, background: "var(--secondary)" }}>
+          {selectedNode && <NodeInspector node={selectedNode} />}
+        </div>
+      </div>
+    </>
+  );
+};
+
+const NodeInspector = ({ node }: { node: GraphNode }) => {
+  const meta = TYPE_META[node.type];
+  const edges = GRAPH.edges.filter(([s, t]) => s === node.id || t === node.id);
+  return (
+    <>
+      <div>
+        <div className="metric-label">選択中ノード</div>
+        <div className="row" style={{ gap: 8, marginTop: 6 }}>
+          <div style={{ width: 32, height: 32, borderRadius: 8, background: "var(--background)", border: `2px solid ${RISK_COLOR[node.risk]}`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <Icon name={meta.icon} size={16} />
+          </div>
+          <div>
+            <div style={{ fontWeight: 500, fontSize: 14 }}>{node.label}</div>
+            <div className="muted mono" style={{ fontSize: 11 }}>{node.type} · {node.meta}</div>
+          </div>
+        </div>
+        <div className="row" style={{ marginTop: 10, gap: 6 }}>
+          <Sev level={node.risk} />
+          <span className="mono muted" style={{ fontSize: 11 }}>{node.id}</span>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-hd"><h3>Blast Radius</h3><span className="hd-meta">2HOPS</span></div>
+        <div className="card-body" style={{ padding: 12, fontSize: 12 }}>
+          <div className="row" style={{ justifyContent: "space-between", marginBottom: 6 }}>
+            <span className="muted">影響ユーザー</span><span className="mono tabular">1,284</span>
+          </div>
+          <div className="row" style={{ justifyContent: "space-between", marginBottom: 6 }}>
+            <span className="muted">影響ブラウザ</span><span className="mono tabular">3,842</span>
+          </div>
+          <div className="row" style={{ justifyContent: "space-between", marginBottom: 6 }}>
+            <span className="muted">データクラス</span><span className="mono tabular">PII, 財務, ソース</span>
+          </div>
+          <div className="row" style={{ justifyContent: "space-between" }}>
+            <span className="muted">到達性</span><Badge variant="danger">直接</Badge>
+          </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-hd"><h3>関係 ({edges.length})</h3></div>
+        <div>
+          {edges.slice(0, 8).map(([s, t, rel], i) => {
+            const other = s === node.id ? t : s;
+            const n = GRAPH.nodes.find(x => x.id === other)!;
+            return (
+              <div key={i} className="list-row" style={{ gridTemplateColumns: "14px 1fr auto", padding: "8px 12px", fontSize: 12, borderBottom: i === edges.length - 1 ? "none" : undefined }}>
+                <Icon name={TYPE_META[n.type].icon} size={11} color="muted" />
+                <div>
+                  <div style={{ fontWeight: 500 }}>{n.label}</div>
+                  <div className="muted mono" style={{ fontSize: 10 }}>{rel}</div>
+                </div>
+                <Dot color={RISK_COLOR[n.risk]} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-hd"><h3>アクション</h3></div>
+        <div className="card-body" style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <button type="button" className="btn" style={{ justifyContent: "flex-start" }}><Icon name="search" size={12} /> フォレンジック開始</button>
+          <button type="button" className="btn" style={{ justifyContent: "flex-start" }}><Icon name="shield" size={12} /> セッション隔離</button>
+          <button type="button" className="btn" style={{ justifyContent: "flex-start" }}><Icon name="key-round" size={12} /> セッション失効</button>
+          <button type="button" className="btn danger" style={{ justifyContent: "flex-start" }}><Icon name="ban" size={12} /> ブラウザ一時停止</button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/app/audit-enterprise/src/pages/Overview.tsx
+++ b/app/audit-enterprise/src/pages/Overview.tsx
@@ -160,8 +160,13 @@ const RiskViz = ({ kind, value, data }: { kind: RiskViz; value: number; data: nu
 
 const TrendChart = ({ data }: { data: number[] }) => {
   const w = 320, h = 120, pad = 8;
-  const max = Math.max(...data);
-  const min = Math.min(...data) - 5;
+  let max = data[0];
+  let min = data[0];
+  for (const v of data) {
+    if (v > max) max = v;
+    if (v < min) min = v;
+  }
+  min -= 5;
   const step = (w - pad * 2) / (data.length - 1);
   const pts = data.map((d, i) => [pad + i * step, h - pad - ((d - min) / (max - min)) * (h - pad * 2)] as const);
   const line = pts.map((p, i) => `${i === 0 ? "M" : "L"}${p[0]},${p[1]}`).join(" ");

--- a/app/audit-enterprise/src/pages/Overview.tsx
+++ b/app/audit-enterprise/src/pages/Overview.tsx
@@ -1,0 +1,252 @@
+import type { DashboardData } from "../data";
+import { Badge, Dot, Heatmap, Icon, Metric, PageHeader, RiskBarScore, Sev, Sparkline } from "../components/ui";
+
+export type RiskViz = "bar" | "heatmap";
+
+export const OverviewPage = ({ data, riskViz }: { data: DashboardData; riskViz: RiskViz }) => {
+  const d = data;
+  return (
+    <>
+      <PageHeader
+        title="セキュリティ概要"
+        kicker="OVERVIEW"
+        sub="ゼロトラスト・ブラウザセキュリティのリアルタイム姿勢。BDR / CASB / 拡張機能リスクを統合した経営ダッシュボード。"
+        actions={
+          <>
+            <div className="seg">
+              <button type="button" className="active">24時間</button>
+              <button type="button">7日</button>
+              <button type="button">30日</button>
+            </div>
+            <button type="button" className="btn"><Icon name="download" size={12} /> エクスポート</button>
+            <button type="button" className="btn accent"><Icon name="file-text" size={12} /> 経営レポート</button>
+          </>
+        }
+      />
+      <div className="page-body">
+        <div className="grid" style={{ gridTemplateColumns: "repeat(4, 1fr)", marginBottom: 16 }}>
+          <Metric label="24h アラート" value={d.stats.alerts24h} delta={d.stats.alertsDelta} sub="前日比" spark={[12, 14, 11, 9, 18, 22, 15, 19, 14, 11, 8, 12]} />
+          <Metric label="ブロック済" value={d.stats.blocked24h} delta={d.stats.blockedDelta} sub="ポリシー+BDR" spark={[4, 6, 8, 11, 9, 14, 18, 22, 19, 24, 28, 34]} />
+          <Metric label="漏洩疑い" value={d.stats.exfilEvents} delta={d.stats.exfilDelta} sub="PII/機密" spark={[3, 4, 6, 5, 8, 7, 9, 11, 8, 10, 9, 11]} />
+          <Metric label="MTTR" value={d.stats.mttrMin} unit="分" delta={d.stats.mttrDelta} sub="平均対応時間" spark={[22, 19, 18, 20, 17, 15, 16, 14, 15, 13, 14, 14]} />
+        </div>
+
+        <div className="grid" style={{ gridTemplateColumns: "320px 1fr 1fr", marginBottom: 16 }}>
+          <div className="card">
+            <div className="card-hd">
+              <h3>組織リスクスコア</h3>
+              <span className="hd-meta">{riskViz.toUpperCase()}</span>
+            </div>
+            <div className="card-body" style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8 }}>
+              <RiskViz kind={riskViz} value={d.risk.score} data={d.risk.trend} />
+              <div style={{ textAlign: "center" }}>
+                <div className="row" style={{ gap: 6, justifyContent: "center" }}>
+                  <Badge variant="warning">{d.risk.grade}</Badge>
+                  <span className="metric-delta up">▲ {d.risk.scoreDelta} (24h)</span>
+                </div>
+                <div className="pleno-small" style={{ marginTop: 6 }}>
+                  14 critical · 87 high · 342 medium
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card-hd">
+              <h3>リスク分解</h3>
+              <span className="hd-meta">重み付きスコア</span>
+            </div>
+            <div className="card-body" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+              {d.risk.breakdown.map(b => (
+                <div key={b.key} className="col" style={{ gap: 4 }}>
+                  <div className="row" style={{ justifyContent: "space-between", fontSize: 12 }}>
+                    <span>{b.label}</span>
+                    <span className="mono muted">w {b.weight}% · <span style={{ color: "var(--foreground)" }}>{b.score}</span></span>
+                  </div>
+                  <RiskBarScore value={b.score} />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card-hd">
+              <h3>14日間トレンド</h3>
+              <span className="hd-meta">LAST UPDATED 09:14</span>
+            </div>
+            <div className="card-body" style={{ padding: 10 }}>
+              <TrendChart data={d.risk.trend} />
+              <div className="row" style={{ marginTop: 12, gap: 16, flexWrap: "wrap", fontSize: 11 }}>
+                <Legend color="var(--danger)" label="critical + high" />
+                <Legend color="var(--warning)" label="medium" />
+                <Legend color="var(--info)" label="info" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid" style={{ gridTemplateColumns: "1.4fr 1fr" }}>
+          <div className="card">
+            <div className="card-hd">
+              <h3>優先度の高い脅威</h3>
+              <span className="hd-meta">CVSS × 到達性 × 資産価値</span>
+            </div>
+            <div>
+              {d.topThreats.map((t, i) => (
+                <div key={t.id} className="list-row" style={{ gridTemplateColumns: "80px 70px 1fr 160px 90px 30px", borderBottom: i === d.topThreats.length - 1 ? "none" : undefined }}>
+                  <span className="mono muted" style={{ fontSize: 11 }}>{t.id}</span>
+                  <Sev level={t.sev} />
+                  <div>
+                    <div style={{ fontWeight: 500, fontSize: 13 }}>{t.title}</div>
+                    <div className="muted" style={{ fontSize: 11, marginTop: 2 }}>{t.asset}</div>
+                  </div>
+                  <Sparkline data={t.trend} width={150} height={22} color="var(--danger)" fill />
+                  <span className="mono tabular" style={{ fontSize: 12 }}>{t.count.toLocaleString()} 件</span>
+                  <Icon name="chevron-right" size={14} color="muted" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card-hd">
+              <h3>フリート姿勢</h3>
+              <span className="hd-meta">{d.org.managedBrowsers.toLocaleString()} ブラウザ</span>
+            </div>
+            <div className="card-body">
+              <PostureSummary />
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+const RiskViz = ({ kind, value, data }: { kind: RiskViz; value: number; data: number[] }) => {
+  if (kind === "bar") {
+    return (
+      <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: 6, padding: "16px 8px" }}>
+        <div className="row" style={{ justifyContent: "space-between" }}>
+          <span className="metric-val tabular" style={{ fontSize: 44 }}>{value}</span>
+          <span className="muted" style={{ fontSize: 11, alignSelf: "flex-end", paddingBottom: 8 }}>/ 100</span>
+        </div>
+        <div style={{ position: "relative", height: 14, background: "var(--tertiary)", borderRadius: 7, overflow: "hidden", border: "1px solid var(--border)" }}>
+          <div style={{
+            position: "absolute", left: 0, top: 0, bottom: 0, width: `${value}%`,
+            background: "linear-gradient(90deg, var(--success) 0%, var(--info) 40%, var(--warning) 70%, var(--danger) 100%)",
+          }} />
+          <div style={{ position: "absolute", left: `${value}%`, top: -4, bottom: -4, width: 2, background: "var(--foreground)" }} />
+        </div>
+        <div className="row" style={{ justifyContent: "space-between", fontSize: 10, color: "var(--muted-foreground)", fontFamily: "var(--font-mono)" }}>
+          <span>0 SAFE</span><span>40</span><span>60</span><span>80</span><span>100 CRIT</span>
+        </div>
+      </div>
+    );
+  }
+  const seed = data.map(v => v / 100);
+  const cells = Array.from({ length: 84 }, (_, i) => {
+    const s = seed[i % seed.length];
+    return Math.min(1, s + ((i * 0.13) % 0.4) - 0.15 + (value / 100) * 0.3);
+  });
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "8px 0" }}>
+      <div style={{ fontSize: 40, fontWeight: 400, letterSpacing: "-0.02em", fontVariantNumeric: "tabular-nums", lineHeight: 1 }}>{value}</div>
+      <Heatmap data={cells} cols={14} rows={6} cellSize={14} />
+      <div className="muted" style={{ fontSize: 10, textTransform: "uppercase", letterSpacing: "0.08em" }}>14日 × 6カテゴリ</div>
+    </div>
+  );
+};
+
+const TrendChart = ({ data }: { data: number[] }) => {
+  const w = 320, h = 120, pad = 8;
+  const max = Math.max(...data);
+  const min = Math.min(...data) - 5;
+  const step = (w - pad * 2) / (data.length - 1);
+  const pts = data.map((d, i) => [pad + i * step, h - pad - ((d - min) / (max - min)) * (h - pad * 2)] as const);
+  const line = pts.map((p, i) => `${i === 0 ? "M" : "L"}${p[0]},${p[1]}`).join(" ");
+  const area = `${line} L${pts[pts.length - 1][0]},${h - pad} L${pts[0][0]},${h - pad} Z`;
+  return (
+    <svg width="100%" viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" style={{ display: "block" }}>
+      {[0.25, 0.5, 0.75].map(t => (
+        <line key={t} x1={pad} x2={w - pad} y1={pad + (h - pad * 2) * t} y2={pad + (h - pad * 2) * t} stroke="var(--border-light)" />
+      ))}
+      <path d={area} fill="var(--accent)" opacity="0.1" />
+      <path d={line} stroke="var(--accent)" strokeWidth="1.5" fill="none" strokeLinecap="round" />
+      {pts.map((p, i) => i === pts.length - 1 && (
+        <circle key={i} cx={p[0]} cy={p[1]} r="3" fill="var(--accent)" stroke="var(--background)" strokeWidth="1.5" />
+      ))}
+    </svg>
+  );
+};
+
+const Legend = ({ color, label }: { color: string; label: string }) => (
+  <span className="row" style={{ gap: 5 }}>
+    <span className="dot" style={{ background: color }} />
+    <span className="muted">{label}</span>
+  </span>
+);
+
+const PostureSummary = () => {
+  const rows = [
+    { label: "最新バージョン", value: 48290, pct: 0.826, status: "success" },
+    { label: "古いバージョン", value: 7842, pct: 0.134, status: "warning" },
+    { label: "EoL / 未パッチ", value: 2300, pct: 0.04, status: "danger" },
+  ];
+  const extRows = [
+    { label: "承認済み拡張", value: 41822, status: "success" },
+    { label: "レビュー待ち", value: 208, status: "warning" },
+    { label: "禁止対象", value: 14, status: "danger" },
+  ];
+  const regions: Array<[string, number, string]> = [
+    ["APAC-TYO", 22140, "success"],
+    ["APAC-SIN", 14428, "success"],
+    ["NA-IAD", 12984, "warning"],
+    ["EU-FRA", 8880, "success"],
+  ];
+  return (
+    <div className="col" style={{ gap: 14 }}>
+      <div>
+        <div className="metric-label" style={{ marginBottom: 8 }}>ブラウザバージョン</div>
+        <div style={{ display: "flex", height: 8, borderRadius: 4, overflow: "hidden", border: "1px solid var(--border)" }}>
+          {rows.map(r => (
+            <div key={r.label} style={{ flex: r.pct, background: `var(--${r.status})` }} />
+          ))}
+        </div>
+        <div className="col" style={{ marginTop: 10, gap: 4 }}>
+          {rows.map(r => (
+            <div key={r.label} className="row" style={{ justifyContent: "space-between", fontSize: 12 }}>
+              <span className="row" style={{ gap: 6 }}><Dot color={`var(--${r.status})`} /> {r.label}</span>
+              <span className="mono tabular">{r.value.toLocaleString()}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div style={{ borderTop: "1px solid var(--border-light)", paddingTop: 12 }}>
+        <div className="metric-label" style={{ marginBottom: 8 }}>拡張機能</div>
+        <div className="col" style={{ gap: 4 }}>
+          {extRows.map(r => (
+            <div key={r.label} className="row" style={{ justifyContent: "space-between", fontSize: 12 }}>
+              <span className="row" style={{ gap: 6 }}><Dot color={`var(--${r.status})`} /> {r.label}</span>
+              <span className="mono tabular">{r.value.toLocaleString()}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div style={{ borderTop: "1px solid var(--border-light)", paddingTop: 12 }}>
+        <div className="metric-label" style={{ marginBottom: 8 }}>リージョン分布</div>
+        <div className="col" style={{ gap: 4 }}>
+          {regions.map(([r, n, s]) => (
+            <div key={r} className="row" style={{ justifyContent: "space-between", fontSize: 12 }}>
+              <span className="mono" style={{ fontSize: 11 }}>{r}</span>
+              <span className="row" style={{ gap: 6 }}>
+                <span className="mono tabular muted">{n.toLocaleString()}</span>
+                <Dot color={`var(--${s})`} size={6} />
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/audit-enterprise/src/pages/Posture.tsx
+++ b/app/audit-enterprise/src/pages/Posture.tsx
@@ -1,0 +1,269 @@
+import { useState } from "react";
+import type { DashboardData, Severity } from "../data";
+import { Badge, Dot, Icon, Metric, PageHeader, RiskBarScore, Sev, Sparkline } from "../components/ui";
+
+export const FleetPage = ({ data }: { data: DashboardData }) => {
+  const [region, setRegion] = useState<string>("all");
+  const [risk, setRisk] = useState<string>("all");
+  const filtered = data.browsers.filter(b =>
+    (region === "all" || b.region === region) &&
+    (risk === "all" || b.risk === risk),
+  );
+  return (
+    <>
+      <PageHeader
+        title="ブラウザフリート"
+        kicker="FLEET INVENTORY"
+        sub={`${data.org.managedBrowsers.toLocaleString()} 台の管理ブラウザ・${data.org.managedUsers.toLocaleString()} ユーザー。姿勢、パッチ状況、EDRエージェント連携を可視化。`}
+        actions={<>
+          <button type="button" className="btn"><Icon name="download" size={12} /> CSVエクスポート</button>
+          <button type="button" className="btn accent"><Icon name="refresh-cw" size={12} /> 同期</button>
+        </>}
+      />
+      <div className="page-body">
+        <div className="row" style={{ gap: 10, marginBottom: 14, flexWrap: "wrap" }}>
+          <div className="seg">
+            {["all", ...data.org.regions].map(r => (
+              <button type="button" key={r} className={region === r ? "active" : ""} onClick={() => setRegion(r)}>{r === "all" ? "全リージョン" : r}</button>
+            ))}
+          </div>
+          <div className="seg">
+            {["all", "critical", "high", "medium", "low"].map(r => (
+              <button type="button" key={r} className={risk === r ? "active" : ""} onClick={() => setRisk(r)}>{r === "all" ? "全リスク" : r}</button>
+            ))}
+          </div>
+          <span className="muted mono" style={{ fontSize: 11, marginLeft: "auto" }}>{filtered.length} / {data.browsers.length} 表示</span>
+        </div>
+
+        <div className="list">
+          <div className="list-hd" style={{ gridTemplateColumns: "80px 1fr 1.2fr 140px 140px 70px 90px 60px 80px 90px" }}>
+            <span>ID</span><span>ホスト</span><span>ユーザー</span><span>OS</span><span>ブラウザ</span><span>リスク</span><span>アラート</span><span>拡張</span><span>最終</span><span>リージョン</span>
+          </div>
+          {filtered.map(b => (
+            <div key={b.id} className="list-row" style={{ gridTemplateColumns: "80px 1fr 1.2fr 140px 140px 70px 90px 60px 80px 90px" }}>
+              <span className="mono" style={{ fontSize: 11 }}>{b.id}</span>
+              <span style={{ fontWeight: 500, fontSize: 12 }}>{b.host}</span>
+              <span style={{ fontSize: 12 }}>{b.user}</span>
+              <span className="muted mono" style={{ fontSize: 11 }}>{b.os}</span>
+              <span className="muted mono" style={{ fontSize: 11 }}>{b.browser}</span>
+              <Sev level={b.risk} />
+              <span className="mono tabular">{b.alerts}</span>
+              <span className="mono tabular muted">{b.ext}</span>
+              <span className="muted" style={{ fontSize: 11 }}>{b.lastSeen}</span>
+              <span className="mono" style={{ fontSize: 10, color: "var(--muted-foreground)" }}>{b.region}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid" style={{ gridTemplateColumns: "1fr 1fr 1fr", gap: 14, marginTop: 16 }}>
+          <div className="card">
+            <div className="card-hd"><h3>EDR連携</h3><span className="hd-meta">CROWDSTRIKE</span></div>
+            <div className="card-body"><div className="metric-val tabular">98.2%</div><div className="muted" style={{ fontSize: 11 }}>57,384 / 58,432 報告中</div><div style={{ marginTop: 8 }}><RiskBarScore value={98.2} color="var(--success)" /></div></div>
+          </div>
+          <div className="card">
+            <div className="card-hd"><h3>ディスク暗号化</h3></div>
+            <div className="card-body"><div className="metric-val tabular">99.7%</div><div className="muted" style={{ fontSize: 11 }}>FileVault / BitLocker</div><div style={{ marginTop: 8 }}><RiskBarScore value={99.7} color="var(--success)" /></div></div>
+          </div>
+          <div className="card">
+            <div className="card-hd"><h3>DLPエージェント</h3></div>
+            <div className="card-body"><div className="metric-val tabular">76.4%</div><div className="muted" style={{ fontSize: 11 }}>未導入: 13,790台</div><div style={{ marginTop: 8 }}><RiskBarScore value={76.4} color="var(--warning)" /></div></div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export const ExtensionsPage = ({ data }: { data: DashboardData }) => (
+  <>
+    <PageHeader
+      title="拡張機能リスク"
+      kicker="EXTENSION GOVERNANCE"
+      sub="組織内の全Chrome拡張機能を監査。権限スコープ、パブリッシャー検証、Chrome Web Store異常挙動を分析。"
+      actions={<>
+        <button type="button" className="btn"><Icon name="upload" size={12} /> 許可リストをインポート</button>
+        <button type="button" className="btn accent"><Icon name="shield-check" size={12} /> 承認ポリシー</button>
+      </>}
+    />
+    <div className="page-body">
+      <div className="grid" style={{ gridTemplateColumns: "repeat(4, 1fr)", marginBottom: 16 }}>
+        <Metric label="検出された拡張" value={1842} sub="ユニーク" />
+        <Metric label="承認済" value={1624} sub="88%" />
+        <Metric label="禁止対象" value={14} delta={+2} sub="要削除" />
+        <Metric label="レビュー待ち" value={204} delta={+18} />
+      </div>
+
+      <div className="list">
+        <div className="list-hd" style={{ gridTemplateColumns: "1.4fr 80px 90px 1fr 1fr 1fr" }}>
+          <span>拡張機能</span><span>インストール</span><span>リスク</span><span>権限</span><span>パブリッシャー</span><span>備考</span>
+        </div>
+        {data.extensions.map((e, i) => (
+          <div key={i} className="list-row" style={{ gridTemplateColumns: "1.4fr 80px 90px 1fr 1fr 1fr", alignItems: "flex-start" }}>
+            <div>
+              <div style={{ fontWeight: 500, fontSize: 13 }}>{e.name}</div>
+              <div className="muted mono" style={{ fontSize: 10, marginTop: 2 }}>{e.id}</div>
+              <div className="muted" style={{ fontSize: 11, marginTop: 2 }}>初検出: {e.firstSeen}</div>
+            </div>
+            <span className="mono tabular">{e.installs.toLocaleString()}</span>
+            <Sev level={e.risk} />
+            <span className="row" style={{ gap: 4, flexWrap: "wrap" }}>
+              {e.perms.map(p => (
+                <Badge key={p} variant={p === "<all_urls>" || p === "debugger" || p === "nativeMessaging" ? "danger" : "default"}>{p}</Badge>
+              ))}
+            </span>
+            <span style={{ fontSize: 12 }}>{e.publisher}</span>
+            <div>
+              <Badge variant={e.status === "禁止対象" ? "danger" : e.status === "承認済" ? "success" : "warning"}>{e.status}</Badge>
+              {e.note && <div className="muted" style={{ fontSize: 11, marginTop: 4 }}>{e.note}</div>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </>
+);
+
+export const SaasPage = ({ data }: { data: DashboardData }) => (
+  <>
+    <PageHeader
+      title="SaaS & AI ディスカバリ"
+      kicker="SHADOW IT · GENAI"
+      sub="ブラウザから検出した全SaaSと生成AI利用を可視化。承認状態、機密度、AI宛データ送信量を追跡。"
+      actions={<>
+        <button type="button" className="btn"><Icon name="filter" size={12} /> フィルタ</button>
+        <button type="button" className="btn accent"><Icon name="book-open" size={12} /> AI利用ポリシー</button>
+      </>}
+    />
+    <div className="page-body">
+      <div className="grid" style={{ gridTemplateColumns: "repeat(4, 1fr)", marginBottom: 16 }}>
+        <Metric label="検出されたSaaS" value={418} delta={+34} sub="シャドーIT含む" />
+        <Metric label="GenAI利用者" value={38420} delta={+1200} sub="過去30日" spark={[18000, 22000, 26000, 30000, 33000, 36000, 38420]} />
+        <Metric label="AI宛データ送信" value="1.8" unit="GB" delta={+62} sub="24h" />
+        <Metric label="未承認SaaS" value={42} delta={+4} sub="要レビュー" />
+      </div>
+
+      <div className="list">
+        <div className="list-hd" style={{ gridTemplateColumns: "1.3fr 80px 90px 90px 80px 80px 80px 100px 80px" }}>
+          <span>サービス</span><span>カテゴリ</span><span>承認</span><span>ユーザー</span><span>機密度</span><span>リスク</span><span>漏洩</span><span>AI送信</span><span>トレンド</span>
+        </div>
+        {data.saasApps.map((s, i) => (
+          <div key={i} className="list-row" style={{ gridTemplateColumns: "1.3fr 80px 90px 90px 80px 80px 80px 100px 80px" }}>
+            <span className="row" style={{ gap: 8, minWidth: 0 }}>
+              <span style={{ flexShrink: 0, width: 22, height: 22, borderRadius: 5, background: "var(--tertiary)", border: "1px solid var(--border)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, fontWeight: 500 }}>
+                {s.name.charAt(0)}
+              </span>
+              <span className="ellip" style={{ fontWeight: 500 }}>{s.name}</span>
+            </span>
+            <Badge variant="default">{s.cat}</Badge>
+            <Badge variant={s.sanction === "承認済" ? "success" : s.sanction === "条件付" ? "warning" : s.sanction === "禁止" ? "danger" : "default"}>{s.sanction}</Badge>
+            <span className="mono tabular">{s.users.toLocaleString()}</span>
+            <Sev level={s.sensitivity as Severity} />
+            <Sev level={s.risk as Severity} />
+            <span className="mono tabular">{s.exfil}</span>
+            <span className="mono tabular" style={{ color: s.aiIngress > 200 ? "var(--danger-foreground)" : "var(--foreground)" }}>{s.aiIngress.toLocaleString()}</span>
+            <Sparkline data={s.trend} width={60} height={20} color={s.risk === "critical" ? "var(--danger)" : "var(--accent)"} fill />
+          </div>
+        ))}
+      </div>
+    </div>
+  </>
+);
+
+export const PolicyPage = ({ data }: { data: DashboardData }) => (
+  <>
+    <PageHeader
+      title="ポリシーエンジン"
+      kicker="CASB · DLP RULES"
+      sub="ユーザーアクションとデータフローに対するリアルタイム制御。貼り付け、アップロード、フォーム送信、URLカテゴリを含む。"
+      actions={<>
+        <button type="button" className="btn"><Icon name="file-text" size={12} /> テンプレート</button>
+        <button type="button" className="btn accent"><Icon name="plus" size={12} /> 新規ルール</button>
+      </>}
+    />
+    <div className="page-body">
+      <div className="grid" style={{ gridTemplateColumns: "1fr 320px", gap: 14, marginBottom: 16 }}>
+        <div className="card">
+          <div className="card-hd"><h3>アクティブルール</h3><span className="hd-meta">{data.policies.length} RULES</span></div>
+          <div className="list-hd" style={{ gridTemplateColumns: "80px 1.5fr 1fr 1fr 80px 90px 70px", borderRadius: 0 }}>
+            <span>ID</span><span>ルール名</span><span>スコープ</span><span>アクション</span><span>24h</span><span>最終</span><span>状態</span>
+          </div>
+          {data.policies.map(p => (
+            <div key={p.id} className="list-row" style={{ gridTemplateColumns: "80px 1.5fr 1fr 1fr 80px 90px 70px" }}>
+              <span className="mono" style={{ fontSize: 11 }}>{p.id}</span>
+              <span style={{ fontWeight: 500, fontSize: 12 }}>{p.name}</span>
+              <span className="muted" style={{ fontSize: 12 }}>{p.scope}</span>
+              <span className="row" style={{ gap: 4 }}>
+                <Badge variant={p.action.includes("ブロック") ? "danger" : "info"}>{p.action.split("+")[0]}</Badge>
+                {p.action.includes("+") && <span className="muted" style={{ fontSize: 10 }}>+{p.action.split("+")[1]}</span>}
+              </span>
+              <span className="mono tabular">{p.hits24h}</span>
+              <span className="mono muted" style={{ fontSize: 11 }}>{p.last}</span>
+              <Badge variant={p.state === "有効" ? "success" : "default"}>{p.state}</Badge>
+            </div>
+          ))}
+        </div>
+
+        <div className="col" style={{ gap: 14 }}>
+          <div className="card">
+            <div className="card-hd"><h3>データクラス</h3></div>
+            <div className="card-body" style={{ display: "flex", flexDirection: "column", gap: 8, fontSize: 12 }}>
+              {([
+                ["PII (氏名/住所/電話)", 284, "danger"],
+                ["財務 (口座/決算)", 112, "danger"],
+                ["認証情報 (PW/トークン)", 68, "danger"],
+                ["ソースコード", 44, "warning"],
+                ["顧客データ", 202, "warning"],
+                ["内部文書", 128, "info"],
+              ] as const).map(([l, n, v]) => (
+                <div key={l} className="row" style={{ justifyContent: "space-between" }}>
+                  <span className="row" style={{ gap: 6 }}><Dot color={`var(--${v})`} /> {l}</span>
+                  <span className="mono tabular">{n}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="card">
+            <div className="card-hd"><h3>URLカテゴリ</h3></div>
+            <div className="card-body" style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12 }}>
+              {([
+                ["AI / LLM", "条件付"],
+                ["暗号資産", "ブロック"],
+                ["ファイル共有", "監視"],
+                ["個人メール", "警告"],
+                ["ギャンブル", "ブロック"],
+                ["ソーシャル", "監視"],
+              ] as const).map(([c, a]) => (
+                <div key={c} className="row" style={{ justifyContent: "space-between" }}>
+                  <span>{c}</span>
+                  <Badge variant={a === "ブロック" ? "danger" : a === "警告" ? "warning" : "info"}>{a}</Badge>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-hd"><h3>ルール編集: P-001 "AI経由のPII漏洩防止"</h3><span className="hd-meta">EDITOR PREVIEW</span></div>
+        <div style={{ padding: 20, display: "grid", gridTemplateColumns: "80px 1fr 80px 1fr 80px 1fr", gap: 10, alignItems: "center", fontSize: 12 }}>
+          <span className="muted mono">WHEN</span>
+          <div style={{ padding: "8px 12px", background: "var(--tertiary)", border: "1px solid var(--border)", borderRadius: 6 }}>
+            チャネル = <span className="mono">貼り付け | POST | フォーム送信</span>
+          </div>
+          <span className="muted mono">AND</span>
+          <div style={{ padding: "8px 12px", background: "var(--tertiary)", border: "1px solid var(--border)", borderRadius: 6 }}>
+            送信先 ∈ <span className="mono">{"{chatgpt.com, claude.ai, perplexity.ai, gemini.google.com}"}</span>
+          </div>
+          <span className="muted mono">AND</span>
+          <div style={{ padding: "8px 12px", background: "var(--tertiary)", border: "1px solid var(--border)", borderRadius: 6 }}>
+            データクラス ⊃ <span className="mono">{"{PII, 財務, 認証}"}</span>
+          </div>
+          <span className="muted mono">THEN</span>
+          <div style={{ padding: "8px 12px", background: "var(--danger-bg)", border: "1px solid var(--danger-border)", borderRadius: 6, color: "var(--danger-foreground)", gridColumn: "2 / span 5" }}>
+            <Icon name="shield-off" size={12} /> ブロック + ユーザー通知 + SIEMへ送信 + ケース自動作成
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+);

--- a/app/audit-enterprise/src/style.css
+++ b/app/audit-enterprise/src/style.css
@@ -1,0 +1,305 @@
+/* ============================================================
+ * Pleno ZTBS Enterprise — Colors & Type
+ * Aligned with app/audit-extension theme.
+ * ============================================================ */
+
+:root {
+  --background: #ffffff;
+  --foreground: #111111;
+  --primary: #000000;
+  --primary-foreground: #ffffff;
+  --secondary: #fafafa;
+  --secondary-foreground: #111111;
+  --tertiary: #f5f5f5;
+  --muted: #555555;
+  --muted-foreground: #555555;
+  --border: #eaeaea;
+  --border-light: #f5f5f5;
+
+  --success: #22c55e;
+  --success-foreground: #0a7227;
+  --success-bg: #d3f9d8;
+  --success-border: #b8f0c0;
+
+  --warning: #f59e0b;
+  --warning-foreground: #915b00;
+  --warning-bg: #fff8e6;
+  --warning-border: #ffe58f;
+
+  --danger: #ef4444;
+  --danger-foreground: #cc0000;
+  --danger-bg: #ffeeee;
+  --danger-border: #ffcccc;
+
+  --info: #3b82f6;
+  --info-foreground: #0050b3;
+  --info-bg: #e6f4ff;
+  --info-border: #91caff;
+
+  --link: #0070f3;
+
+  --accent: #4f46e5;
+  --accent-bg: #eef2ff;
+  --accent-border: #c7d2fe;
+  --accent-foreground: #3730a3;
+  --graph-node-critical: #ef4444;
+  --graph-node-high: #f59e0b;
+  --graph-node-medium: #3b82f6;
+  --graph-node-safe: #22c55e;
+
+  --scrollbar-track: hsl(0 0% 95%);
+  --scrollbar-thumb: hsl(0 0% 75%);
+  --scrollbar-thumb-hover: hsl(0 0% 60%);
+
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN",
+    "Hiragino Sans", Meiryo, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas,
+    "Liberation Mono", monospace;
+
+  --fs-xs: 11px;
+  --fs-sm: 12px;
+  --fs-md: 13px;
+  --fs-base: 14px;
+  --fs-lg: 15px;
+  --fs-xl: 17px;
+  --fs-xxl: 21px;
+}
+
+.dark {
+  color-scheme: dark;
+  --background: #1a1a1a;
+  --foreground: #e5e5e5;
+  --primary: #ffffff;
+  --primary-foreground: #000000;
+  --secondary: #222222;
+  --secondary-foreground: #e5e5e5;
+  --tertiary: #2a2a2a;
+  --muted: #b0b0b0;
+  --muted-foreground: #b0b0b0;
+  --border: #333333;
+  --border-light: #2a2a2a;
+
+  --success: #4ade80;
+  --success-foreground: #4ade80;
+  --success-bg: #0a3d1a;
+  --success-border: #166534;
+  --warning: #fbbf24;
+  --warning-foreground: #fbbf24;
+  --warning-bg: #3d2e0a;
+  --warning-border: #92400e;
+  --danger: #f87171;
+  --danger-foreground: #f87171;
+  --danger-bg: #3d0a0a;
+  --danger-border: #991b1b;
+  --info: #60a5fa;
+  --info-foreground: #60a5fa;
+  --info-bg: #0a2a3d;
+  --info-border: #1e40af;
+  --link: #60a5fa;
+
+  --accent: #818cf8;
+  --accent-bg: #1e1b4b;
+  --accent-border: #3730a3;
+  --accent-foreground: #a5b4fc;
+
+  --scrollbar-track: #2a2a2a;
+  --scrollbar-thumb: #555555;
+  --scrollbar-thumb-hover: #666666;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body, #root { height: 100%; }
+body {
+  font-family: var(--font-sans);
+  font-size: var(--fs-base);
+  color: var(--foreground);
+  background: var(--secondary);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+button { font-family: inherit; }
+
+.app { display: flex; flex-direction: column; height: 100vh; min-height: 600px; }
+.app-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 20px; background: var(--background);
+  border-bottom: 1px solid var(--border); flex-shrink: 0; height: 52px;
+  white-space: nowrap;
+}
+.brand { display: flex; align-items: center; gap: 10px; flex-shrink: 0; white-space: nowrap; }
+.brand-mark { width: 22px; height: 22px; border-radius: 5px; background: var(--primary); color: var(--primary-foreground); display: inline-flex; align-items: center; justify-content: center; font-weight: 500; font-size: 13px; }
+.brand-name { font-size: 15px; font-weight: 500; letter-spacing: -0.01em; }
+.brand-sub { font-size: 10px; color: var(--muted-foreground); text-transform: uppercase; letter-spacing: 0.08em; font-family: var(--font-mono); padding: 2px 6px; border: 1px solid var(--border); border-radius: 4px; margin-left: 4px; }
+
+.hd-search {
+  flex: 1 1 auto;
+  max-width: 420px;
+  margin: 0 24px;
+  display: grid;
+  grid-template-columns: 16px 1fr auto;
+  grid-template-rows: 30px;
+  align-items: center;
+  column-gap: 8px;
+  padding: 0 10px;
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  transition: border-color 0.15s, background 0.15s;
+  box-sizing: border-box;
+}
+.hd-search:focus-within { border-color: var(--primary); background: var(--background); }
+.hd-search > input { align-self: center; grid-column: 2; width: 100%; height: 28px; padding: 0; background: transparent; border: 0; font-family: inherit; font-size: 12px; color: var(--foreground); outline: none; line-height: 28px; }
+.hd-search .kbd { grid-column: 3; align-self: center; font-family: var(--font-mono); font-size: 10px; color: var(--muted-foreground); border: 1px solid var(--border); padding: 1px 5px; border-radius: 3px; background: var(--background); line-height: 1.4; }
+
+.hd-right { display: flex; align-items: center; gap: 10px; flex-shrink: 0; white-space: nowrap; }
+.hd-status { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; color: var(--muted-foreground); font-family: var(--font-mono); white-space: nowrap; }
+.hd-status .pulse { width: 6px; height: 6px; border-radius: 50%; background: var(--success); position: relative; }
+.hd-status .pulse::after { content: ""; position: absolute; inset: -3px; border: 1px solid var(--success); border-radius: 50%; opacity: 0.3; }
+.icon-btn { width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; background: transparent; border: 1px solid transparent; border-radius: 6px; cursor: pointer; color: var(--muted-foreground); }
+.icon-btn:hover { background: var(--tertiary); border-color: var(--border); color: var(--foreground); }
+.hd-org {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 4px 10px; border: 1px solid var(--border); border-radius: 6px;
+  background: var(--background); cursor: pointer; font-size: 12px;
+  white-space: nowrap; max-width: 220px;
+}
+.hd-org > span:not(.avatar) { overflow: hidden; text-overflow: ellipsis; }
+.hd-org:hover { background: var(--tertiary); }
+.hd-org .avatar { width: 18px; height: 18px; border-radius: 4px; background: var(--accent); color: white; display: inline-flex; align-items: center; justify-content: center; font-size: 10px; font-weight: 500; }
+
+.body { display: flex; flex: 1; min-height: 0; }
+.sb {
+  width: 220px; min-width: 220px; background: var(--background);
+  border-right: 1px solid var(--border); padding: 12px 0;
+  display: flex; flex-direction: column; gap: 1px;
+  position: relative; overflow-y: auto;
+}
+.sb-section { font-size: 10px; font-weight: 500; color: var(--muted-foreground); letter-spacing: 0.08em; text-transform: uppercase; padding: 10px 18px 4px; }
+.sb-ind { position: absolute; left: 0; width: 2px; background: var(--primary); border-radius: 0 1px 1px 0; transition: top 0.25s cubic-bezier(0.4,0,0.2,1), height 0.25s cubic-bezier(0.4,0,0.2,1); }
+.tab {
+  display: flex; align-items: center; gap: 10px; padding: 7px 18px;
+  background: transparent; color: var(--muted-foreground); border: none;
+  font-family: inherit; font-size: 13px; text-align: left; cursor: pointer;
+  transition: background 0.15s, color 0.15s; font-weight: 400; width: 100%;
+}
+.tab:hover { background: var(--secondary); color: var(--foreground); }
+.tab.active { background: var(--secondary); color: var(--foreground); font-weight: 500; }
+.tab .tab-label { flex: 1; }
+.tab .tab-count {
+  display: inline-flex; align-items: center; padding: 0 6px; font-size: 10px; font-weight: 500;
+  border-radius: 9999px; background: var(--danger-bg); color: var(--danger-foreground);
+  border: 1px solid var(--danger-border); min-height: 16px;
+}
+.tab .tab-count.info { background: var(--info-bg); color: var(--info-foreground); border-color: var(--info-border); }
+
+.sb-foot { margin-top: auto; padding: 10px 18px; border-top: 1px solid var(--border); font-size: 11px; color: var(--muted-foreground); }
+.sb-foot .region { display: flex; align-items: center; gap: 6px; margin-top: 4px; font-family: var(--font-mono); }
+
+.main {
+  flex: 1; overflow: auto; background: var(--secondary);
+  display: flex; flex-direction: column; min-width: 0;
+}
+.page-header {
+  padding: 18px 24px 14px; background: var(--background);
+  border-bottom: 1px solid var(--border); display: flex; align-items: flex-end; justify-content: space-between; gap: 24px;
+}
+.page-header .title-row { display: flex; align-items: baseline; gap: 10px; }
+.page-title { font-size: 20px; font-weight: 500; letter-spacing: -0.01em; color: var(--foreground); }
+.page-kicker { font-size: 10px; color: var(--muted-foreground); font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.1em; padding: 2px 6px; border: 1px solid var(--border); border-radius: 4px; }
+.page-sub { font-size: 12px; color: var(--muted-foreground); margin-top: 4px; max-width: 60ch; line-height: 1.5; }
+.page-actions { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
+
+.page-body { padding: 20px 24px; flex: 1; }
+
+.card { background: var(--background); border: 1px solid var(--border); border-radius: 8px; }
+.card-hd { padding: 12px 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.card-hd h3 { font-size: 13px; font-weight: 500; color: var(--foreground); }
+.card-hd .hd-meta { font-size: 11px; color: var(--muted-foreground); font-family: var(--font-mono); }
+.card-body { padding: 16px; }
+
+.btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px; border-radius: 6px; border: 1px solid var(--border);
+  background: var(--background); color: var(--foreground); cursor: pointer;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  transition: all 0.15s;
+}
+.btn:hover { background: var(--tertiary); }
+.btn.primary { background: var(--primary); color: var(--primary-foreground); border-color: var(--primary); }
+.btn.primary:hover { opacity: 0.88; background: var(--primary); }
+.btn.accent { background: var(--accent); color: white; border-color: var(--accent); }
+.btn.accent:hover { opacity: 0.88; background: var(--accent); }
+.btn.ghost { background: transparent; border-color: transparent; color: var(--muted-foreground); }
+.btn.ghost:hover { background: var(--tertiary); color: var(--foreground); }
+.btn.sm { padding: 4px 8px; font-size: 11px; }
+.btn.danger { color: var(--danger-foreground); border-color: var(--danger-border); }
+
+.b { display: inline-flex; align-items: center; gap: 4px; padding: 1px 6px; font-size: 10px; font-weight: 500; border-radius: 9999px; border: 1px solid; line-height: 1.5; font-family: var(--font-sans); }
+.b.default { background: var(--tertiary); color: var(--muted-foreground); border-color: var(--border); }
+.b.success { background: var(--success-bg); color: var(--success-foreground); border-color: var(--success-border); }
+.b.warning { background: var(--warning-bg); color: var(--warning-foreground); border-color: var(--warning-border); }
+.b.danger  { background: var(--danger-bg);  color: var(--danger-foreground);  border-color: var(--danger-border); }
+.b.info    { background: var(--info-bg);    color: var(--info-foreground);    border-color: var(--info-border); }
+.b.accent  { background: var(--accent-bg);  color: var(--accent-foreground);  border-color: var(--accent-border); }
+
+.input {
+  padding: 7px 10px; border: 1px solid var(--border); border-radius: 6px;
+  font-size: 12px; font-family: inherit; background: var(--background); color: var(--foreground);
+  outline: none; transition: border-color 0.15s;
+}
+.input:focus { border-color: var(--primary); }
+
+.chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 10px; font-size: 11px; font-weight: 500;
+  border-radius: 9999px; border: 1px solid var(--border);
+  background: var(--background); color: var(--muted-foreground);
+  cursor: pointer; font-family: inherit; transition: all 0.15s;
+}
+.chip:hover { background: var(--tertiary); }
+.chip.active { background: var(--primary); color: var(--primary-foreground); border-color: var(--primary); }
+
+.seg { display: inline-flex; background: var(--tertiary); border: 1px solid var(--border); border-radius: 6px; padding: 2px; gap: 2px; }
+.seg button {
+  background: transparent; border: none; padding: 4px 10px; font-size: 11px; font-weight: 500;
+  color: var(--muted-foreground); border-radius: 4px; cursor: pointer; font-family: inherit; transition: all 0.15s;
+}
+.seg button.active { background: var(--background); color: var(--foreground); box-shadow: 0 0 0 1px var(--border) inset; }
+
+.list { display: flex; flex-direction: column; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; background: var(--background); }
+.list-hd, .list-row { display: grid; gap: 12px; padding: 10px 16px; align-items: center; }
+.list-hd { background: var(--secondary); border-bottom: 1px solid var(--border); font-size: 10px; font-weight: 500; color: var(--muted-foreground); text-transform: uppercase; letter-spacing: 0.06em; }
+.list-row { border-bottom: 1px solid var(--border-light); font-size: 13px; transition: background 0.12s; cursor: pointer; }
+.list-row:last-child { border-bottom: none; }
+.list-row:hover { background: var(--secondary); }
+.list-row.selected { background: var(--accent-bg); }
+
+.muted { color: var(--muted-foreground); }
+.mono { font-family: var(--font-mono); }
+.row { display: flex; align-items: center; gap: 8px; }
+.col { display: flex; flex-direction: column; gap: 8px; }
+.grow { flex: 1; }
+.spacer { flex: 1; }
+.ellip { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nowrap { white-space: nowrap; }
+.grid { display: grid; gap: 16px; }
+.dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.tabular { font-variant-numeric: tabular-nums; }
+
+.metric-label { font-size: 11px; color: var(--muted-foreground); text-transform: uppercase; letter-spacing: 0.08em; font-weight: 500; }
+.metric-val { font-size: 28px; font-weight: 400; letter-spacing: -0.02em; font-variant-numeric: tabular-nums; line-height: 1; }
+.metric-delta { font-size: 11px; font-family: var(--font-mono); }
+.metric-delta.up { color: var(--danger-foreground); }
+.metric-delta.down { color: var(--success-foreground); }
+
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 6px; border: 2px solid var(--secondary); }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
+
+.graph-node-label { font-size: 10px; font-family: var(--font-sans); fill: var(--foreground); pointer-events: none; }
+
+.pleno-link { color: var(--link); text-decoration: none; cursor: pointer; }
+.pleno-link:hover { text-decoration: underline; }
+.pleno-small { font-size: 13px; color: var(--muted-foreground); }

--- a/app/audit-enterprise/src/vite-env.d.ts
+++ b/app/audit-enterprise/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/app/audit-enterprise/tsconfig.json
+++ b/app/audit-enterprise/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowImportingTsExtensions": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/app/audit-enterprise/tsconfig.node.json
+++ b/app/audit-enterprise/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2023"],
+    "moduleDetection": "force",
+    "composite": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/app/audit-enterprise/vite.config.ts
+++ b/app/audit-enterprise/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  base: "/pleno-audit/enterprise/",
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "website:build": "pnpm -C app/website build",
     "battacker-web": "pnpm -C app/battacker-web dev",
     "battacker-web:build": "pnpm --filter @libztbs/battacker build && pnpm -C app/battacker-web build",
+    "enterprise": "pnpm -C app/audit-enterprise dev",
+    "enterprise:build": "pnpm -C app/audit-enterprise build",
     "typecheck": "tsc -p tsconfig.packages.json --noEmit",
     "lint": "oxlint .",
     "test": "vitest run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 9.6.0(@stryker-mutator/core@9.6.0(@types/node@25.5.0))(typescript@6.0.2)
       '@stryker-mutator/vitest-runner':
         specifier: ^9.6.0
-        version: 9.6.0(@stryker-mutator/core@9.6.0(@types/node@25.5.0))(vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)))
+        version: 9.6.0(@stryker-mutator/core@9.6.0(@types/node@25.5.0))(vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -34,7 +34,7 @@ importers:
         version: 0.1.38
       '@vitest/coverage-v8':
         specifier: ^4.1.2
-        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)))
+        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)))
       concurrently:
         specifier: ^9.1.2
         version: 9.2.1
@@ -55,10 +55,38 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
       ws:
         specifier: ^8.20.0
         version: 8.20.0
+
+  app/audit-enterprise:
+    dependencies:
+      lucide-react:
+        specifier: ^1.7.0
+        version: 1.7.0(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
 
   app/audit-extension:
     dependencies:
@@ -77,13 +105,13 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.60.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.60.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
       wxt:
         specifier: ^0.20.20
-        version: 0.20.20(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(tsx@4.21.0)
+        version: 0.20.20(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.1)(tsx@4.21.0)
 
   app/battacker-e2e:
     dependencies:
@@ -118,10 +146,10 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.60.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.60.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
       wxt:
         specifier: ^0.20.20
-        version: 0.20.20(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(tsx@4.21.0)
+        version: 0.20.20(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.1)(tsx@4.21.0)
 
   app/battacker-web:
     dependencies:
@@ -146,13 +174,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+        version: 6.0.1(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
       vite:
         specifier: ^8.0.6
-        version: 8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+        version: 8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
 
   app/debugger:
     dependencies:
@@ -202,7 +230,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.2.2(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -211,7 +239,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+        version: 6.0.1(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -220,7 +248,7 @@ importers:
         version: 6.0.2
       vite:
         specifier: ^8.0.6
-        version: 8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+        version: 8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
 
   packages/core:
     dependencies:
@@ -554,166 +582,166 @@ packages:
     hasBin: true
 
   '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==, tarball: https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz}
 
   '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==, tarball: https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz}
 
   '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==, tarball: https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz}
 
   '@esbuild/aix-ppc64@0.27.5':
-    resolution: {integrity: sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==}
+    resolution: {integrity: sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==, tarball: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.27.5':
-    resolution: {integrity: sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==}
+    resolution: {integrity: sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.27.5':
-    resolution: {integrity: sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==}
+    resolution: {integrity: sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.27.5':
-    resolution: {integrity: sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==}
+    resolution: {integrity: sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.27.5':
-    resolution: {integrity: sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==}
+    resolution: {integrity: sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.5':
-    resolution: {integrity: sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==}
+    resolution: {integrity: sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.27.5':
-    resolution: {integrity: sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==}
+    resolution: {integrity: sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.5':
-    resolution: {integrity: sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==}
+    resolution: {integrity: sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.27.5':
-    resolution: {integrity: sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==}
+    resolution: {integrity: sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.5':
-    resolution: {integrity: sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==}
+    resolution: {integrity: sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.27.5':
-    resolution: {integrity: sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==}
+    resolution: {integrity: sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.5':
-    resolution: {integrity: sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==}
+    resolution: {integrity: sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.27.5':
-    resolution: {integrity: sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==}
+    resolution: {integrity: sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.5':
-    resolution: {integrity: sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==}
+    resolution: {integrity: sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.27.5':
-    resolution: {integrity: sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==}
+    resolution: {integrity: sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.5':
-    resolution: {integrity: sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==}
+    resolution: {integrity: sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.5':
-    resolution: {integrity: sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==}
+    resolution: {integrity: sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-arm64@0.27.5':
-    resolution: {integrity: sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==}
+    resolution: {integrity: sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==, tarball: https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.5':
-    resolution: {integrity: sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==}
+    resolution: {integrity: sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.27.5':
-    resolution: {integrity: sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==}
+    resolution: {integrity: sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==, tarball: https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.5':
-    resolution: {integrity: sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==}
+    resolution: {integrity: sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openharmony-arm64@0.27.5':
-    resolution: {integrity: sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==}
+    resolution: {integrity: sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==, tarball: https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
   '@esbuild/sunos-x64@0.27.5':
-    resolution: {integrity: sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==}
+    resolution: {integrity: sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.27.5':
-    resolution: {integrity: sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==}
+    resolution: {integrity: sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.27.5':
-    resolution: {integrity: sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==}
+    resolution: {integrity: sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.5':
-    resolution: {integrity: sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==}
+    resolution: {integrity: sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -739,134 +767,134 @@ packages:
     engines: {node: '>=18'}
 
   '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==, tarball: https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==, tarball: https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==, tarball: https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz}
     cpu: [arm64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==, tarball: https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz}
     cpu: [arm64]
     os: [linux]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz}
     cpu: [arm]
     os: [linux]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz}
     cpu: [ppc64]
     os: [linux]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz}
     cpu: [riscv64]
     os: [linux]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz}
     cpu: [s390x]
     os: [linux]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz}
     cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz}
     cpu: [arm64]
     os: [linux]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz}
     cpu: [x64]
     os: [linux]
 
   '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==, tarball: https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
   '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==, tarball: https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
 
   '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==, tarball: https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
 
   '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==, tarball: https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
 
   '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==, tarball: https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
 
   '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==, tarball: https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==, tarball: https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==, tarball: https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
   '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==, tarball: https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
   '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==, tarball: https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [win32]
 
   '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==, tarball: https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==, tarball: https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -1040,8 +1068,14 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@napi-rs/wasm-runtime@1.1.2':
+    resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==, tarball: https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==, tarball: https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1058,119 +1092,122 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oxc-project/types@0.124.0':
-    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@oxc-project/types@0.126.0':
+    resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==, tarball: https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz}
 
   '@oxlint/binding-android-arm-eabi@1.58.0':
-    resolution: {integrity: sha512-1T7UN3SsWWxpWyWGn1cT3ASNJOo+pI3eUkmEl7HgtowapcV8kslYpFQcYn431VuxghXakPNlbjRwhqmR37PFOg==}
+    resolution: {integrity: sha512-1T7UN3SsWWxpWyWGn1cT3ASNJOo+pI3eUkmEl7HgtowapcV8kslYpFQcYn431VuxghXakPNlbjRwhqmR37PFOg==, tarball: https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
   '@oxlint/binding-android-arm64@1.58.0':
-    resolution: {integrity: sha512-GryzujxuiRv2YFF7bRy8mKcxlbuAN+euVUtGJt9KKbLT8JBUIosamVhcthLh+VEr6KE6cjeVMAQxKAzJcoN7dg==}
+    resolution: {integrity: sha512-GryzujxuiRv2YFF7bRy8mKcxlbuAN+euVUtGJt9KKbLT8JBUIosamVhcthLh+VEr6KE6cjeVMAQxKAzJcoN7dg==, tarball: https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
   '@oxlint/binding-darwin-arm64@1.58.0':
-    resolution: {integrity: sha512-7/bRSJIwl4GxeZL9rPZ11anNTyUO9epZrfEJH/ZMla3+/gbQ6xZixh9nOhsZ0QwsTW7/5J2A/fHbD1udC5DQQA==}
+    resolution: {integrity: sha512-7/bRSJIwl4GxeZL9rPZ11anNTyUO9epZrfEJH/ZMla3+/gbQ6xZixh9nOhsZ0QwsTW7/5J2A/fHbD1udC5DQQA==, tarball: https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
   '@oxlint/binding-darwin-x64@1.58.0':
-    resolution: {integrity: sha512-EqdtJSiHweS2vfILNrpyJ6HUwpEq2g7+4Zx1FPi4hu3Hu7tC3znF6ufbXO8Ub2LD4mGgznjI7kSdku9NDD1Mkg==}
+    resolution: {integrity: sha512-EqdtJSiHweS2vfILNrpyJ6HUwpEq2g7+4Zx1FPi4hu3Hu7tC3znF6ufbXO8Ub2LD4mGgznjI7kSdku9NDD1Mkg==, tarball: https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
   '@oxlint/binding-freebsd-x64@1.58.0':
-    resolution: {integrity: sha512-VQt5TH4M42mY20F545G637RKxV/yjwVtKk2vfXuazfReSIiuvWBnv+FVSvIV5fKVTJNjt3GSJibh6JecbhGdBw==}
+    resolution: {integrity: sha512-VQt5TH4M42mY20F545G637RKxV/yjwVtKk2vfXuazfReSIiuvWBnv+FVSvIV5fKVTJNjt3GSJibh6JecbhGdBw==, tarball: https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
   '@oxlint/binding-linux-arm-gnueabihf@1.58.0':
-    resolution: {integrity: sha512-fBYcj4ucwpAtjJT3oeBdFBYKvNyjRSK+cyuvBOTQjh0jvKp4yeA4S/D0IsCHus/VPaNG5L48qQkh+Vjy3HL2/Q==}
+    resolution: {integrity: sha512-fBYcj4ucwpAtjJT3oeBdFBYKvNyjRSK+cyuvBOTQjh0jvKp4yeA4S/D0IsCHus/VPaNG5L48qQkh+Vjy3HL2/Q==, tarball: https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
   '@oxlint/binding-linux-arm-musleabihf@1.58.0':
-    resolution: {integrity: sha512-0BeuFfwlUHlJ1xpEdSD1YO3vByEFGPg36uLjK1JgFaxFb4W6w17F8ET8sz5cheZ4+x5f2xzdnRrrWv83E3Yd8g==}
+    resolution: {integrity: sha512-0BeuFfwlUHlJ1xpEdSD1YO3vByEFGPg36uLjK1JgFaxFb4W6w17F8ET8sz5cheZ4+x5f2xzdnRrrWv83E3Yd8g==, tarball: https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
   '@oxlint/binding-linux-arm64-gnu@1.58.0':
-    resolution: {integrity: sha512-TXlZgnPTlxrQzxG9ZXU7BNwx1Ilrr17P3GwZY0If2EzrinqRH3zXPc3HrRcBJgcsoZNMuNL5YivtkJYgp467UQ==}
+    resolution: {integrity: sha512-TXlZgnPTlxrQzxG9ZXU7BNwx1Ilrr17P3GwZY0If2EzrinqRH3zXPc3HrRcBJgcsoZNMuNL5YivtkJYgp467UQ==, tarball: https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
   '@oxlint/binding-linux-arm64-musl@1.58.0':
-    resolution: {integrity: sha512-zSoYRo5dxHLcUx93Stl2hW3hSNjPt99O70eRVWt5A1zwJ+FPjeCCANCD2a9R4JbHsdcl11TIQOjyigcRVOH2mw==}
+    resolution: {integrity: sha512-zSoYRo5dxHLcUx93Stl2hW3hSNjPt99O70eRVWt5A1zwJ+FPjeCCANCD2a9R4JbHsdcl11TIQOjyigcRVOH2mw==, tarball: https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
   '@oxlint/binding-linux-ppc64-gnu@1.58.0':
-    resolution: {integrity: sha512-NQ0U/lqxH2/VxBYeAIvMNUK1y0a1bJ3ZicqkF2c6wfakbEciP9jvIE4yNzCFpZaqeIeRYaV7AVGqEO1yrfVPjA==}
+    resolution: {integrity: sha512-NQ0U/lqxH2/VxBYeAIvMNUK1y0a1bJ3ZicqkF2c6wfakbEciP9jvIE4yNzCFpZaqeIeRYaV7AVGqEO1yrfVPjA==, tarball: https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
   '@oxlint/binding-linux-riscv64-gnu@1.58.0':
-    resolution: {integrity: sha512-X9J+kr3gIC9FT8GuZt0ekzpNUtkBVzMVU4KiKDSlocyQuEgi3gBbXYN8UkQiV77FTusLDPsovjo95YedHr+3yg==}
+    resolution: {integrity: sha512-X9J+kr3gIC9FT8GuZt0ekzpNUtkBVzMVU4KiKDSlocyQuEgi3gBbXYN8UkQiV77FTusLDPsovjo95YedHr+3yg==, tarball: https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
   '@oxlint/binding-linux-riscv64-musl@1.58.0':
-    resolution: {integrity: sha512-CDze3pi1OO3Wvb/QsXjmLEY4XPKGM6kIo82ssNOgmcl1IdndF9VSGAE38YLhADWmOac7fjqhBw82LozuUVxD0Q==}
+    resolution: {integrity: sha512-CDze3pi1OO3Wvb/QsXjmLEY4XPKGM6kIo82ssNOgmcl1IdndF9VSGAE38YLhADWmOac7fjqhBw82LozuUVxD0Q==, tarball: https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
   '@oxlint/binding-linux-s390x-gnu@1.58.0':
-    resolution: {integrity: sha512-b/89glbxFaEAcA6Uf1FvCNecBJEgcUTsV1quzrqXM/o4R1M4u+2KCVuyGCayN2UpsRWtGGLb+Ver0tBBpxaPog==}
+    resolution: {integrity: sha512-b/89glbxFaEAcA6Uf1FvCNecBJEgcUTsV1quzrqXM/o4R1M4u+2KCVuyGCayN2UpsRWtGGLb+Ver0tBBpxaPog==, tarball: https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
   '@oxlint/binding-linux-x64-gnu@1.58.0':
-    resolution: {integrity: sha512-0/yYpkq9VJFCEcuRlrViGj8pJUFFvNS4EkEREaN7CB1EcLXJIaVSSa5eCihwBGXtOZxhnblWgxks9juRdNQI7w==}
+    resolution: {integrity: sha512-0/yYpkq9VJFCEcuRlrViGj8pJUFFvNS4EkEREaN7CB1EcLXJIaVSSa5eCihwBGXtOZxhnblWgxks9juRdNQI7w==, tarball: https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
   '@oxlint/binding-linux-x64-musl@1.58.0':
-    resolution: {integrity: sha512-hr6FNvmcAXiH+JxSvaJ4SJ1HofkdqEElXICW9sm3/Rd5eC3t7kzvmLyRAB3NngKO2wzXRCAm4Z/mGWfrsS4X8w==}
+    resolution: {integrity: sha512-hr6FNvmcAXiH+JxSvaJ4SJ1HofkdqEElXICW9sm3/Rd5eC3t7kzvmLyRAB3NngKO2wzXRCAm4Z/mGWfrsS4X8w==, tarball: https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
   '@oxlint/binding-openharmony-arm64@1.58.0':
-    resolution: {integrity: sha512-R+O368VXgRql1K6Xar+FEo7NEwfo13EibPMoTv3sesYQedRXd6m30Dh/7lZMxnrQVFfeo4EOfYIP4FpcgWQNHg==}
+    resolution: {integrity: sha512-R+O368VXgRql1K6Xar+FEo7NEwfo13EibPMoTv3sesYQedRXd6m30Dh/7lZMxnrQVFfeo4EOfYIP4FpcgWQNHg==, tarball: https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
   '@oxlint/binding-win32-arm64-msvc@1.58.0':
-    resolution: {integrity: sha512-Q0FZiAY/3c4YRj4z3h9K1PgaByrifrfbBoODSeX7gy97UtB7pySPUQfC2B/GbxWU6k7CzQrRy5gME10PltLAFQ==}
+    resolution: {integrity: sha512-Q0FZiAY/3c4YRj4z3h9K1PgaByrifrfbBoODSeX7gy97UtB7pySPUQfC2B/GbxWU6k7CzQrRy5gME10PltLAFQ==, tarball: https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
   '@oxlint/binding-win32-ia32-msvc@1.58.0':
-    resolution: {integrity: sha512-Y8FKBABrSPp9H0QkRLHDHOSUgM/309a3IvOVgPcVxYcX70wxJrk608CuTg7w+C6vEd724X5wJoNkBcGYfH7nNQ==}
+    resolution: {integrity: sha512-Y8FKBABrSPp9H0QkRLHDHOSUgM/309a3IvOVgPcVxYcX70wxJrk608CuTg7w+C6vEd724X5wJoNkBcGYfH7nNQ==, tarball: https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
   '@oxlint/binding-win32-x64-msvc@1.58.0':
-    resolution: {integrity: sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg==}
+    resolution: {integrity: sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg==, tarball: https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.58.0.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1245,97 +1282,189 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==, tarball: https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.16':
+    resolution: {integrity: sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==, tarball: https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==, tarball: https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
+    resolution: {integrity: sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==, tarball: https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==, tarball: https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.16':
+    resolution: {integrity: sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==, tarball: https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==, tarball: https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
-    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
+    resolution: {integrity: sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==, tarball: https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
+    resolution: {integrity: sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
+    resolution: {integrity: sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
+    resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
+    resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
+    resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
+    resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
+    resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==, tarball: https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==, tarball: https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
-    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
+    resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==, tarball: https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==, tarball: https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
+    resolution: {integrity: sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==, tarball: https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==, tarball: https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
+    resolution: {integrity: sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==, tarball: https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==, tarball: https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.15':
-    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
+    resolution: {integrity: sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==, tarball: https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.12':
+    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+
+  '@rolldown/pluginutils@1.0.0-rc.16':
+    resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==, tarball: https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -1354,127 +1483,127 @@ packages:
         optional: true
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
-    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==, tarball: https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz}
     cpu: [arm]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.60.1':
-    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==, tarball: https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz}
     cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-darwin-arm64@4.60.1':
-    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==, tarball: https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz}
     cpu: [arm64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.60.1':
-    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==, tarball: https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-freebsd-arm64@4.60.1':
-    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==, tarball: https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz}
     cpu: [arm64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.60.1':
-    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==, tarball: https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz}
     cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz}
     cpu: [arm]
     os: [linux]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
-    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz}
     cpu: [arm]
     os: [linux]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz}
     cpu: [arm64]
     os: [linux]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
-    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz}
     cpu: [arm64]
     os: [linux]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz}
     cpu: [loong64]
     os: [linux]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
-    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz}
     cpu: [loong64]
     os: [linux]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz}
     cpu: [ppc64]
     os: [linux]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
-    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz}
     cpu: [ppc64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz}
     cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
-    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz}
     cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz}
     cpu: [s390x]
     os: [linux]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz}
     cpu: [x64]
     os: [linux]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
-    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz}
     cpu: [x64]
     os: [linux]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
-    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==, tarball: https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz}
     cpu: [x64]
     os: [openbsd]
 
   '@rollup/rollup-openharmony-arm64@4.60.1':
-    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==, tarball: https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz}
     cpu: [arm64]
     os: [openharmony]
 
   '@rollup/rollup-win32-arm64-msvc@4.60.1':
-    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz}
     cpu: [arm64]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz}
     cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz}
     cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.60.1':
-    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz}
     cpu: [x64]
     os: [win32]
 
@@ -1522,61 +1651,61 @@ packages:
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
   '@tailwindcss/oxide-android-arm64@4.2.2':
-    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
   '@tailwindcss/oxide-darwin-arm64@4.2.2':
-    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
   '@tailwindcss/oxide-darwin-x64@4.2.2':
-    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
   '@tailwindcss/oxide-freebsd-x64@4.2.2':
-    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
-    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
-    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
-    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
-    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
-    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
-    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -1588,13 +1717,13 @@ packages:
       - tslib
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
-    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
   '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
-    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==, tarball: https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
@@ -1623,7 +1752,7 @@ packages:
       preact: '>=10 || ^10.0.0-alpha.0 || ^10.0.0-beta.0'
 
   '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==, tarball: https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2432,12 +2561,12 @@ packages:
     engines: {node: '>=6 <7 || >=8'}
 
   fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -2905,67 +3034,67 @@ packages:
     resolution: {integrity: sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==}
 
   lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==, tarball: https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
   lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==, tarball: https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==, tarball: https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==, tarball: https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==, tarball: https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
   lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==, tarball: https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==, tarball: https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==, tarball: https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
   lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==, tarball: https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
   lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==, tarball: https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==, tarball: https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
@@ -3447,7 +3576,7 @@ packages:
         optional: true
 
   postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==, tarball: https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
@@ -3625,8 +3754,13 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
-  rolldown@1.0.0-rc.15:
-    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+  rolldown@1.0.0-rc.12:
+    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.0-rc.16:
+    resolution: {integrity: sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==, tarball: https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3935,7 +4069,7 @@ packages:
     engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==, tarball: https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -4101,15 +4235,16 @@ packages:
     peerDependencies:
       vite: 5.x || 6.x || 7.x || 8.x
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@8.0.3:
+    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -4120,11 +4255,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -4141,8 +4278,8 @@ packages:
       yaml:
         optional: true
 
-  vite@8.0.8:
-    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+  vite@8.0.9:
+    resolution: {integrity: sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==, tarball: https://registry.npmjs.org/vite/-/vite-8.0.9.tgz}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -5224,6 +5361,13 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -5243,7 +5387,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@oxc-project/types@0.124.0': {}
+  '@oxc-project/types@0.122.0': {}
+
+  '@oxc-project/types@0.126.0': {}
 
   '@oxlint/binding-android-arm-eabi@1.58.0':
     optional: true
@@ -5318,19 +5464,19 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.60.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.60.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@prefresh/vite': 2.4.12(preact@10.29.0)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+      '@prefresh/vite': 2.4.12(preact@10.29.0)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
       debug: 4.4.3
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
-      vite-prerender-plugin: 0.5.13(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+      vite: 8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+      vite-prerender-plugin: 0.5.13(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - preact
@@ -5345,7 +5491,7 @@ snapshots:
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.29.0)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
+  '@prefresh/vite@2.4.12(preact@10.29.0)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@prefresh/babel-plugin': 0.5.3
@@ -5353,7 +5499,7 @@ snapshots:
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
       preact: 10.29.0
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5380,56 +5526,108 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+  '@rolldown/binding-android-arm64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
     dependencies:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.15': {}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.12': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.16': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -5593,13 +5791,13 @@ snapshots:
 
   '@stryker-mutator/util@9.6.0': {}
 
-  '@stryker-mutator/vitest-runner@9.6.0(@stryker-mutator/core@9.6.0(@types/node@25.5.0))(vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)))':
+  '@stryker-mutator/vitest-runner@9.6.0(@stryker-mutator/core@9.6.0(@types/node@25.5.0))(vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)))':
     dependencies:
       '@stryker-mutator/api': 9.6.0
       '@stryker-mutator/core': 9.6.0(@types/node@25.5.0)
       '@stryker-mutator/util': 9.6.0
       tslib: 2.8.1
-      vitest: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+      vitest: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
 
   '@tailwindcss/node@4.2.2':
     dependencies:
@@ -5662,12 +5860,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -5745,12 +5943,17 @@ snapshots:
     dependencies:
       '@types/node': 25.5.0
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.2
@@ -5762,7 +5965,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+      vitest: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -5773,13 +5976,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.2(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -7653,26 +7856,50 @@ snapshots:
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
 
-  rolldown@1.0.0-rc.15:
+  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
     dependencies:
-      '@oxc-project/types': 0.124.0
-      '@rolldown/pluginutils': 1.0.0-rc.15
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  rolldown@1.0.0-rc.16:
+    dependencies:
+      '@oxc-project/types': 0.126.0
+      '@rolldown/pluginutils': 1.0.0-rc.16
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.16
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.16
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.16
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.16
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.16
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.16
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.16
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.16
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.16
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.16
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.16
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.16
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.16
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.16
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.16
 
   rollup@4.60.1:
     dependencies:
@@ -7969,7 +8196,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
   supports-color@7.2.0:
@@ -8186,7 +8413,7 @@ snapshots:
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -8201,7 +8428,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-prerender-plugin@0.5.13(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)):
+  vite-prerender-plugin@0.5.13(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:
       kolorist: 1.8.0
       magic-string: 0.30.21
@@ -8209,29 +8436,31 @@ snapshots:
       simple-code-frame: 1.3.0
       source-map: 0.7.6
       stack-trace: 1.0.0-pre2
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
 
-  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:
-      esbuild: 0.27.5
-      fdir: 6.5.0(picomatch@4.0.4)
+      lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.8
-      rollup: 4.60.1
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.0
+      esbuild: 0.27.5
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.32.0
       tsx: 4.21.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
-  vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0):
+  vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.10
-      rolldown: 1.0.0-rc.15
+      rolldown: 1.0.0-rc.16
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.5.0
@@ -8240,10 +8469,10 @@ snapshots:
       jiti: 2.6.1
       tsx: 4.21.0
 
-  vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)):
+  vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.2(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -8260,7 +8489,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
@@ -8399,7 +8628,7 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.20(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(tsx@4.21.0):
+  wxt@0.20.20(@types/node@25.5.0)(jiti@2.6.1)(rollup@4.60.1)(tsx@4.21.0):
     dependencies:
       '@1natsu/wait-element': 4.1.2
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.60.1)
@@ -8442,16 +8671,17 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.15
       unimport: 6.0.2
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
       vite-node: 6.0.0(@types/node@25.5.0)(esbuild@0.27.5)(jiti@2.6.1)(tsx@4.21.0)
       web-ext-run: 0.2.4
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@types/node'
       - '@vitejs/devtools'
       - canvas
       - jiti
       - less
-      - lightningcss
       - rollup
       - sass
       - sass-embedded


### PR DESCRIPTION
Claude Design のハンドオフバンドル（Pleno ZTBS Console）を実装した管理者向け Web コンソールを `app/audit-enterprise/` に新設。

## 概要
- Vite + React 19 SPA
- 12 ページ: Overview / Asset Graph / Alerts(BDR) / Forensics / Exfil / Identity / Fleet / Extensions / SaaS & AI / Policy(CASB) / Compliance / Integrations
- `audit-extension` のテーマ変数を共有（ライト／ダーク対応）

## ポリシー適合
- 外部通信禁止: CDN の lucide-static をバンドル版 `lucide-react` に置換、Google favicon 依存を除去
- 外部 DB 非依存: 埋め込みモックデータのみ

## 起動
- \`pnpm enterprise\` で dev server
- \`pnpm enterprise:build\` で本番ビルド（gzip 87KB JS / 3KB CSS）

## 検証
- typecheck / oxlint / build すべて通過
- Chrome で全ページ描画確認済み