### PR TITLE
fix(detector): allowlist Google Fonts / CDNs in dns_prefetch_leak (FP fix)

### DIFF
--- a/app/battacker-e2e/fixtures/fp-smoke-page.html
+++ b/app/battacker-e2e/fixtures/fp-smoke-page.html
@@ -537,20 +537,33 @@
     }
 
     // ============================================================
-    // Pattern 16: Dynamic DNS prefetch (same-site CDN)
-    // DNS prefetch hook skips same-site preconnects
+    // Pattern 16: Dynamic DNS prefetch (same-site CDN + known fonts host)
+    // DNS prefetch hook skips same-site preconnects and KNOWN_PREFETCH_TARGETS
     // ============================================================
     function dynamicDNSPrefetch() {
-      // Same-site preconnect (should be filtered by eTLD+1 check)
-      // On 127.0.0.1, any external domain will trigger, so test with localhost variants
-      var link = document.createElement("link");
-      link.rel = "preconnect";
-      // Note: On localhost, there's no meaningful "same-site" domain to test
-      // This tests the dynamic injection path works without crashing
-      link.href = "http://127.0.0.1:3000"; // same host
-      document.head.appendChild(link);
-      setTimeout(function () { link.remove(); }, 500);
-      record("Dynamic DNS Prefetch", true, "Same-host preconnect injected dynamically");
+      // (a) Same-site preconnect (filtered by eTLD+1 check)
+      // On 127.0.0.1, any external domain will trigger, so test with localhost variants.
+      var link1 = document.createElement("link");
+      link1.rel = "preconnect";
+      link1.href = "http://127.0.0.1:3000"; // same host
+      document.head.appendChild(link1);
+
+      // (b) Google Fonts preconnect (issue #414 regression):
+      // Gmail and other SaaS dynamically insert this for font optimization.
+      // Must be filtered by KNOWN_PREFETCH_TARGETS allowlist, not raised as a leak.
+      var link2 = document.createElement("link");
+      link2.rel = "preconnect";
+      link2.href = "https://fonts.googleapis.com/";
+      document.head.appendChild(link2);
+
+      var link3 = document.createElement("link");
+      link3.rel = "preconnect";
+      link3.href = "https://fonts.gstatic.com/";
+      link3.crossOrigin = "anonymous";
+      document.head.appendChild(link3);
+
+      setTimeout(function () { link1.remove(); link2.remove(); link3.remove(); }, 500);
+      record("Dynamic DNS Prefetch", true, "Same-host + Google Fonts preconnect injected dynamically");
     }
 
     // ============================================================

--- a/packages/core/src/alerts/playbooks/data-exfiltration.ts
+++ b/packages/core/src/alerts/playbooks/data-exfiltration.ts
@@ -257,7 +257,7 @@ export const dataExfiltrationPlaybooks: PlaybookData[] = [
     mitreAttack: ['T1048.003', 'T1071.004'],
     detection: {
       mechanism:
-        'MutationObserverでDOMへの<link>要素の動的追加を監視します。rel属性がdns-prefetch、preconnect、prefetch、preload、prerenderのいずれかで、hrefが外部ドメイン（ルートドメインが異なる）を指す場合にアラートを発火します。同一ルートドメインのサブドメインは除外されます。',
+        'MutationObserverでDOMへの<link>要素の動的追加を監視します。rel属性がdns-prefetch、preconnect、prefetch、preload、prerenderのいずれかで、hrefが外部ドメイン（ルートドメインが異なる）を指す場合にアラートを発火します。同一ルートドメインのサブドメインは除外されます。Google Fontsや主要CDN等、悪用される可能性が低い既知の正規ターゲット（KNOWN_PREFETCH_TARGETS）はアロウリストで除外されます。',
       monitoredAPIs: [
         'MutationObserver（document.head, document.body）',
         'HTMLLinkElement',
@@ -300,7 +300,7 @@ export const dataExfiltrationPlaybooks: PlaybookData[] = [
       'Trusted Typesを導入し、動的なDOM操作を制御する',
     ],
     falsePositives:
-      'パフォーマンス最適化のためにdns-prefetchやpreconnectを動的に追加するWebアプリケーション（SPAのルーティング時等）では正常な動作として検知されます。href先が既知のCDNやAPIサーバーであれば誤検知です。',
+      '既知の正規 preconnect/dns-prefetch ターゲット（Google Fonts、主要CDN等）は KNOWN_PREFETCH_TARGETS アロウリストでスキップされます。アロウリスト外のホストでも、SPAのルーティング時のパフォーマンス最適化として動的に追加されることがあり、href先が既知のAPIサーバーや業務上正規のサードパーティであれば誤検知の可能性があります。',
     relatedAlerts: ['data_exfiltration', 'fetch_exfiltration', 'tracking_beacon'],
   },
 

--- a/packages/core/src/main-world-hooks/security-hooks.test.ts
+++ b/packages/core/src/main-world-hooks/security-hooks.test.ts
@@ -6,6 +6,8 @@
 import { describe, it, expect } from "vitest";
 import {
   KNOWN_CDNS,
+  KNOWN_PREFETCH_TARGETS,
+  isKnownPrefetchTarget,
   SENSITIVE_TYPES,
   SENSITIVE_NAMES,
   CRYPTO_PATTERNS,
@@ -43,6 +45,50 @@ describe("KNOWN_CDNS", () => {
 
   it("does not match non-CDN domains", () => {
     expect(KNOWN_CDNS.some(cdn => "evil-cdn.example.com".includes(cdn))).toBe(false);
+  });
+});
+
+describe("KNOWN_PREFETCH_TARGETS / isKnownPrefetchTarget", () => {
+  it("includes Google Fonts hosts (issue #414 regression)", () => {
+    expect(KNOWN_PREFETCH_TARGETS).toContain("fonts.googleapis.com");
+    expect(KNOWN_PREFETCH_TARGETS).toContain("fonts.gstatic.com");
+  });
+
+  it("inherits all entries from KNOWN_CDNS", () => {
+    for (const cdn of KNOWN_CDNS) {
+      expect(KNOWN_PREFETCH_TARGETS).toContain(cdn);
+    }
+  });
+
+  it("returns true for exact-match allowlisted hosts", () => {
+    expect(isKnownPrefetchTarget("fonts.googleapis.com")).toBe(true);
+    expect(isKnownPrefetchTarget("fonts.gstatic.com")).toBe(true);
+    expect(isKnownPrefetchTarget("cdn.jsdelivr.net")).toBe(true);
+  });
+
+  it("returns true for legitimate subdomain (suffix match)", () => {
+    // Hypothetical regional subdomain — still matches via `.<entry>` suffix
+    expect(isKnownPrefetchTarget("eu.fonts.googleapis.com")).toBe(true);
+  });
+
+  it("is case-insensitive on the input hostname", () => {
+    expect(isKnownPrefetchTarget("FONTS.GOOGLEAPIS.COM")).toBe(true);
+  });
+
+  it("rejects substring-bypass attempts (suffix boundary required)", () => {
+    // Attacker domain that contains the allowlisted name as a substring
+    // but does not end on a label boundary — must NOT pass.
+    expect(isKnownPrefetchTarget("evil-fonts.googleapis.com.attacker.tld")).toBe(false);
+    expect(isKnownPrefetchTarget("fonts.googleapis.com.attacker.tld")).toBe(false);
+    expect(isKnownPrefetchTarget("xfonts.googleapis.com")).toBe(false);
+  });
+
+  it("rejects unknown external hosts", () => {
+    expect(isKnownPrefetchTarget("attacker.example.com")).toBe(false);
+    expect(isKnownPrefetchTarget("leak.test")).toBe(false);
+    // The covert.ts attack synthesizes a subdomain under leak.test —
+    // it must NOT match the allowlist.
+    expect(isKnownPrefetchTarget("6c65616b65645f73657373696f6e.leak.test")).toBe(false);
   });
 });
 

--- a/packages/core/src/main-world-hooks/security-hooks.ts
+++ b/packages/core/src/main-world-hooks/security-hooks.ts
@@ -21,6 +21,38 @@ export const KNOWN_CDNS = [
   "cdn.bootcdn.net", "lib.baomitu.com", "cdn.staticfile.org",
 ];
 
+/**
+ * 既知の正規 preconnect / dns-prefetch ターゲット。
+ * 大手SPA（Gmail、SaaS等）がフォント・CDN最適化のために動的に <link rel="preconnect">
+ * を挿入するケースを誤検知しないためのアロウリスト。
+ *
+ * 比較は完全一致または `.<entry>` サフィックス一致のみ許可する（部分一致は使わない）：
+ * `evil-fonts.googleapis.com.attacker.tld` のような bypass を防ぐため。
+ *
+ * 追加候補は「DNS漏洩経路として悪用される可能性が低く、かつ複数の正規Webアプリが
+ * パフォーマンス最適化として preconnect する」ホストに限定する。
+ */
+export const KNOWN_PREFETCH_TARGETS = [
+  // Google Fonts（Gmail、Google Workspace、多数のSaaS が動的 preconnect する）
+  "fonts.googleapis.com",
+  "fonts.gstatic.com",
+  // jsDelivr / unpkg / cdnjs etc. は KNOWN_CDNS と重複するが、
+  // preconnect の合法ターゲットとしても扱うため明示的に列挙する。
+  ...KNOWN_CDNS,
+];
+
+/**
+ * hostname がアロウリストにマッチするか判定する。
+ * 完全一致、または `.<entry>` サフィックス一致のみ true（部分一致は false）。
+ */
+export function isKnownPrefetchTarget(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  for (const entry of KNOWN_PREFETCH_TARGETS) {
+    if (h === entry || h.endsWith("." + entry)) return true;
+  }
+  return false;
+}
+
 export const SENSITIVE_TYPES = ["password", "email", "tel", "credit-card"];
 export const SENSITIVE_NAMES = [
   "password", "passwd", "pwd", "pass", "secret", "token", "api_key", "apikey",
@@ -329,6 +361,9 @@ export function initSecurityHooks(emitSecurityEvent: SharedHookUtils["emitSecuri
             const linkBase = linkHost.split(".").slice(-2).join(".");
             const pageBase = pageHost.split(".").slice(-2).join(".");
             if (linkBase === pageBase) continue;
+            // 既知の正規 preconnect/dns-prefetch ターゲット（フォント・CDN等）はスキップ。
+            // SPA がパフォーマンス最適化のために動的挿入する典型パターンのFPを防ぐ。
+            if (isKnownPrefetchTarget(linkHost)) continue;
           } catch { /* ignore */ }
           deferEmit(emitSecurityEvent, "__DNS_PREFETCH_LEAK_DETECTED__", {
             rel, href, timestamp: Date.now(), pageUrl: window.location.href,


### PR DESCRIPTION
## 概要

Gmail を含む大手 SPA がフォント最適化のために動的挿入する `<link rel="preconnect" href="https://fonts.googleapis.com/">` が `dns_prefetch_leak` で medium severity アラートとして発火していた誤検知 (FP) を修正する。

## 根本原因 (issue #414)

`packages/core/src/main-world-hooks/security-hooks.ts` の MutationObserver は、外部ホスト宛ての `<link rel=preconnect|dns-prefetch|prefetch|preload|prerender>` が DOM に動的追加された時点でアラートを発火する。

- 静的な `<head>` 内の `<link>` は問題なし（observer は `DOMContentLoaded` フォールバック経由で登録されるため、その時点で静的 head はパース済み・mutation として観測されない）。
- 一方 SPA は JS から `DOMContentLoaded` 以降に preconnect を挿入するため、Gmail の `fonts.googleapis.com` のような正規パフォーマンス最適化が検知対象になっていた。
- `KNOWN_CDNS` は存在するが `checkSupplyChainRisk` だけで使われ、preconnect 経路には適用されていなかった。

## 採用した方針 — A: 既知の正規ターゲットのアロウリスト

- B案（preconnect rel をルールから削除）は却下: `<link rel=preconnect>` も DNS 解決が TLS より先行するため、サブドメインに exfil データを乗せる covert channel として悪用可能。検知カバレッジを失う。
- C案（動的挿入のみ検知）は不要: 既に MutationObserver は `DOMContentLoaded` 以降の挿入だけを観測している（実装済み）。

## 変更点

- `security-hooks.ts`:
  - `KNOWN_PREFETCH_TARGETS` を追加（`fonts.googleapis.com`, `fonts.gstatic.com` + `KNOWN_CDNS`）。
  - `isKnownPrefetchTarget(hostname)` を追加。**完全一致または `.<entry>` サフィックス一致のみ true**。`KNOWN_CDNS` の `includes()` ベースの比較が許してしまう `evil-fonts.googleapis.com.attacker.tld` 系の bypass を防ぐためラベル境界で厳密マッチする。
  - 既存の `dnsPrefetchObserver` で eTLD+1 同一サイト check の直後にアロウリストスキップを挟む。
- `fp-smoke-page.html`: dynamic DNS prefetch fixture に `fonts.googleapis.com` / `fonts.gstatic.com` preconnect を追加し、issue #414 の回帰をロックインする。
- `security-hooks.test.ts`: アロウリスト定数 + ヘルパーの単体テスト（exact / suffix / case-insensitive / substring-bypass 拒否 / covert.ts の `.leak.test` を弾くこと）。
- `alerts/playbooks/data-exfiltration.ts`: detection.mechanism と falsePositives 文言をアロウリスト挙動に合わせて更新。

## 検証

- `pnpm typecheck` 成功。
- `pnpm test` 成功（2487 → 2494 tests / +7 新規, 失敗 1 suite は `app/audit-extension/.../utils.test.ts` のtsconfig解決エラーで main にも存在する既知の前提エラー、本変更と無関係）。
- `oxlint` 変更ファイルで warning/error 0。
- 攻撃者シミュレーション `packages/core/src/battacker/attacks/covert.ts` の `<host hex>.leak.test` は **アロウリストに該当せず引き続き検知される**（テストでも明示）。

## issue #414 の事象

> URL: https://mail.google.com/mail/u/0/#inbox
> Title: DNSプリフェッチリーク検出: mail.google.com
> domain: mail.google.com / href: https://fonts.googleapis.com/ / rel: preconnect

このパターンは本PR後は `isKnownPrefetchTarget("fonts.googleapis.com") === true` でスキップされ、アラート未発火となる。