### PR TITLE
fix(dlp): Transformers.js 4.x で start/end オフセット欠落によるマスキング破損を修正

### DIFF
--- a/app/audit-extension/entrypoints/background.ts
+++ b/app/audit-extension/entrypoints/background.ts
@@ -687,10 +687,21 @@ export default defineBackground(() => {
             const validEntities = result.entities.filter(e => e.entity_type != null && e.entity_type !== "");
             if (validEntities.length > 0) {
               const entityTypes = [...new Set(validEntities.map(e => e.entity_type))];
-              const sorted = [...validEntities].sort((a, b) => b.start - a.start);
               let masked = data.text!;
-              for (const ent of sorted) {
-                masked = masked.slice(0, ent.start) + `[${ent.entity_type}]` + masked.slice(ent.end);
+              const entitiesWithOffsets = validEntities.filter(e => e.start != null && e.end != null);
+              if (entitiesWithOffsets.length > 0) {
+                // Offset-based masking (preserves original positions)
+                const sorted = [...entitiesWithOffsets].sort((a, b) => b.start! - a.start!);
+                for (const ent of sorted) {
+                  masked = masked.slice(0, ent.start) + `[${ent.entity_type}]` + masked.slice(ent.end);
+                }
+              } else {
+                // Word-based masking fallback (Transformers.js 4.x: no character offsets)
+                for (const ent of validEntities) {
+                  if (ent.text) {
+                    masked = masked.replaceAll(ent.text, `[${ent.entity_type}]`);
+                  }
+                }
               }
               const maskedSample = masked.length > 200 ? masked.slice(0, 200) + "…" : masked;
               await backgroundAlerts.getAlertManager().alertDLPPIIDetected({

--- a/packages/core/src/ai-detector/dlp-scanner.test.ts
+++ b/packages/core/src/ai-detector/dlp-scanner.test.ts
@@ -114,6 +114,33 @@ describe("createDLPScanner", () => {
     expect(result).toBeNull();
   });
 
+  it("scan handles Transformers.js 4.x grouped output without start/end offsets", async () => {
+    // Transformers.js 4.x groupEntities() omits start/end ("TODO: Add support for start and end")
+    const pipelineResults = [
+      { entity_group: "PERSON", score: 0.95, word: "田中太郎" },
+      { entity_group: "EMAIL_ADDRESS", score: 0.99, word: "tanaka@example.com" },
+    ];
+    mockPipeline.mockResolvedValue(pipelineResults);
+
+    const scanner = createDLPScanner({ enabled: true });
+    await scanner.initPipeline();
+    const result = await scanner.scan(
+      "田中太郎 tanaka@example.com",
+      "clipboard",
+      "example.com",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.entities).toHaveLength(2);
+    expect(result!.entities[0]!.entity_type).toBe("PERSON");
+    expect(result!.entities[0]!.start).toBeUndefined();
+    expect(result!.entities[0]!.end).toBeUndefined();
+    // Falls back to word field when start/end are absent
+    expect(result!.entities[0]!.text).toBe("田中太郎");
+    expect(result!.entities[1]!.entity_type).toBe("EMAIL_ADDRESS");
+    expect(result!.entities[1]!.text).toBe("tanaka@example.com");
+  });
+
   it("scan truncates long text", async () => {
     mockPipeline.mockResolvedValue([]);
     const scanner = createDLPScanner({ enabled: true });

--- a/packages/core/src/ai-detector/dlp-scanner.ts
+++ b/packages/core/src/ai-detector/dlp-scanner.ts
@@ -16,8 +16,10 @@ export type ScanContext = "clipboard" | "form" | "ai_prompt";
 /** 検出されたエンティティ */
 export interface DLPEntity {
   entity_type: string;
-  start: number;
-  end: number;
+  /** character offset (absent in Transformers.js 4.x grouped output) */
+  start?: number;
+  /** character offset (absent in Transformers.js 4.x grouped output) */
+  end?: number;
   score: number;
   text: string;
 }
@@ -81,8 +83,9 @@ interface TokenClassificationResult {
   entity_group: string;
   score: number;
   word: string;
-  start: number;
-  end: number;
+  /** Transformers.js 4.x の grouped 出力では返されない ("TODO: Add support for start and end") */
+  start?: number;
+  end?: number;
 }
 
 type NERPipeline = (
@@ -167,7 +170,8 @@ export function createDLPScanner(initialConfig?: Partial<DLPServerConfig>): DLPS
           start: r.start,
           end: r.end,
           score: r.score,
-          text: trimmed.slice(r.start, r.end),
+          // Transformers.js 4.x grouped output omits start/end; fall back to word
+          text: r.start != null && r.end != null ? trimmed.slice(r.start, r.end) : r.word,
         }));
 
       if (entities.length === 0) {


### PR DESCRIPTION
## Summary

- Transformers.js 3.8.1 → 4.2.0 のバンプ（#421）で `aggregation_strategy: "simple"` の grouped 出力から `start`/`end` character offset が削除された（ライブラリ側のソースに "TODO: Add support for start and end" と明記）
- この変更により DLP マスキングが壊れ、`maskedSample` がテキスト全体を重複する不正な文字列になっていた（例：`"田中太郎[PERSON]田中太郎"` のような出力）
- DLP エンティティ検出自体（entity_type、entityCount）は引き続き正常動作

## Changes

- `DLPEntity.start`/`end` を `optional` に変更（Transformers.js 4.x の実際の型に合わせる）
- `TokenClassificationResult.start`/`end` も `optional` に変更
- `entity.text` を `r.word` でフォールバック（start/end が undefined の場合、`trimmed.slice(undefined, undefined)` = 全文になるバグを修正）
- `background.ts` のマスキングを2段階化：
  - start/end が存在する → offset-based masking（既存の正確な位置マスク）
  - start/end がない → word-based replacement（`replaceAll` で単語ベースのフォールバック）
- Transformers.js 4.x の grouped 出力パターンに対する回帰テストを追加

## Test plan

- [x] `pnpm test --run` → 2495 tests passed (新規テスト1件含む)
- [x] `pnpm build` → ビルド成功（TypeScript エラーなし）
- [ ] 実際の DLP スキャン（ONNX モデル有り）で maskedSample が正しくマスクされることを確認

## Root cause

issue #407 のトリアージ中に発見。#421 の Transformers.js バンプが DLP マスキングに与える影響を確認した。

https://claude.ai/code/session_01Xsr7JsrGTDNkufXyXqod3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xsr7JsrGTDNkufXyXqod3a)_