### PR TITLE
ops: periodic operations improvement (CI reliability, hygiene)

### DIFF
--- a/.agents/skills/create-adr/SKILL.md
+++ b/.agents/skills/create-adr/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: create-adr
+description: >
+  ADR（Architecture Decision Record）を作成するスキル。
+  docs/adr/ にストック情報（永続的な意思決定）のみを記録する。
+  Trigger: ADR作成, 設計決定記録, アーキテクチャ決定を記録
+---
+
+# ADR作成
+
+## ルール
+
+- **ストック情報のみ**: リファクタリング手順やプロセスガイドは記録しない
+- フロー情報（段階的手順、一時的な計画）はgit historyやAGENTS.mdに任せる
+
+## 手順
+
+1. `docs/adr/README.md` を読み、現在の最大番号を取得
+2. 次の番号で `docs/adr/{NNN}-{slug}.md` を作成
+
+```markdown
+# ADR-{NNN}: {タイトル}
+
+## Status
+
+Accepted
+
+## Context
+
+なぜこの決定が必要か。背景と制約。
+
+## Decision
+
+何を決定したか。具体的な方針。
+
+## Consequences
+
+この決定により何が変わるか。トレードオフ。
+```
+
+3. `docs/adr/README.md` のテーブル末尾にエントリを追加
+
+```markdown
+| [{NNN}](./{NNN}-{slug}.md) | {タイトル} | Accepted |
+```
+
+## 判断基準: ADRに記録すべきか
+
+記録する: 技術選定、パッケージ構造、機能設計方針、外部制約への対応
+記録しない: リファクタリングの各ステップ、一時的な計画、開発プロセス

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs on the same PR; never cancel main runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 2 * * 1'
 
+# Cancel superseded runs on the same PR; never cancel main runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,9 @@ jobs:
 
       - name: Merge PR
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge --squash "$PR_URL"
+        # --auto waits for required status checks (see main ruleset) before
+        # merging, so a dependency bump that breaks CI never reaches main.
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4
         with:
-          version: 10
+          version: 9
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,11 @@
 name: Publish
 
+# Trusted publishing is triggered by a dedicated `libztbs-v*` tag, not by
+# every main push. Push such a tag (matching packages/core/package.json
+# version) to release, e.g. `git tag libztbs-v1.3.0 && git push --tags`.
 on:
   push:
-    branches: [main]
+    tags: ["libztbs-v*"]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -34,8 +37,25 @@ jobs:
       - name: Build packages
         run: pnpm --filter libztbs build
 
+      - name: Verify tag matches package version
+        working-directory: packages/core
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#libztbs-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match packages/core/package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
       - name: Publish packages to npm
         working-directory: packages/core
-        run: npx -y npm@11 publish --access public --provenance
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          PUBLISHED=$(npm view "libztbs@${PKG_VERSION}" version 2>/dev/null || true)
+          if [ -n "$PUBLISHED" ]; then
+            echo "libztbs@${PKG_VERSION} is already published, skipping."
+            exit 0
+          fi
+          npx -y npm@11 publish --access public --provenance
         env:
           NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+# Serialize releases on main so concurrent pushes don't race on tag creation.
+# Never cancel an in-progress release (it signs artifacts and cuts releases).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ vite.config.js
 
 *.local.md
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 app/audit-extension/public/sql-wasm.wasm
 
 # Scan data (raw results from security scanners)


### PR DESCRIPTION
定期の運用改善。マルチエージェント監査 workflow (5 次元: CI/CD・deps・policy・hygiene・security) で 21 件を抽出し、敵対的検証で確定した 14 件のうち、lockfile を伴わない高信頼・低リスク修正をバンドル。

## 修正内容

### Critical/High — CI 信頼性
- **fix(ci): publish.yml を `libztbs-v*` tag push 発火に変更** — main push 毎に `npm publish` が走り、version 未 bump のコミットで `cannot publish over previously published version: 1.2.0` が発生（12+ 連続失敗）。専用 tag namespace（release.yml の `v*-<sha>` と衝突しない）+ tag/package.json version 一致検証 + 既публ skip の冪等化。tag-push trusted publishing ポリシーにも整合。

### Medium
- **ci: concurrency guard 追加** (ci/codeql/release) — superseded PR run を cancel、main run は cancel しない。release は tag 作成 race 回避のため非 cancel で直列化。
- **ci: dependabot auto-merge を `--auto` 化** — 即 merge をやめ、main ruleset の必須チェック通過まで待機（壊れた依存更新が main に入り deploy/release/publish を発火するのを防止）。
- **chore: repo hygiene** — 野良 root `AGENTS.md`（tracked `.agents/AGENTS.md` とバイト一致）削除、`.agents/skills/create-adr/SKILL.md`（#274 で `.claude/` のみに追加されたスキルの Codex mirror）を commit して parity 復元、`.claude/scheduled_tasks.lock` を gitignore。

### Low
- **ci: pnpm を全 workflow で v9 に統一** — deploy-website のみ v10 で drift（lockfile は 9.0、挙動差リスク）。

## 別タスクに分離（このPRに含めない）
- **deps: protobufjs `>=7.5.8` override / ws `>=8.20.1` bump** — lockfile 再生成が必要だが、本環境は `~/.npmrc` の private registry proxy（`min-release-age` gating）+ ローカル pnpm 11 vs CI pnpm 9 の解釈差により、再生成で **qs/uuid のセキュリティ floor がダウングレードされる**ことを確認。ダウングレード混入を避けるため clean 環境での再生成を要する別タスクとする。

## リポ設定（PR外、別途適用）
- `sha_pinning_required=true` 有効化
- main ruleset 作成（必須チェック: Test/Build/Lint/Typecheck/UI Tests/Fuzzing Tests、maintainer bypass、PR 必須化なし＝trunk-based 直 push 維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)