### PR TITLE
ci: quote $GITHUB_OUTPUT in release.yml (SC2086)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,8 @@ jobs:
         run: |
           set -e
           VERSION=$(node -p "require('./app/audit-extension/package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Create Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2


### PR DESCRIPTION
## Summary

Fixes the minor shellcheck SC2086 finding from #428 (`>> $GITHUB_OUTPUT` → `>> "$GITHUB_OUTPUT"` in the `Get version` step).

This is independent of the release-model decision (Option 1 vs Option 2) described in #428 and can land ahead of it.

## Changes

- `release.yml`: quote `$GITHUB_OUTPUT` in both `echo` redirect lines of the `Get version` step.

Closes the minor item in #428.